### PR TITLE
Fix empty logs modals by skipping LIMIT clause when numberOfLogs is null

### DIFF
--- a/php/api/token-api.php
+++ b/php/api/token-api.php
@@ -55,12 +55,24 @@ function wpqt_register_token_api_routes()
                 $cachedDbToken = ServiceLocator::get('ApiTokenService')->getRequestTokenCache(WP_QUICKTASKER_CACHED_API_DB_TOKEN);
                 $pipeline = ServiceLocator::get('PipelineRepository')->getPipelineById($cachedDbToken->pipeline_id);
                 $responseService = ServiceLocator::get('ResponseService');
+                $apiTokenRepository = ServiceLocator::get('ApiTokenRepository');
 
                 if (!$pipeline) {
                     return $responseService->createTokenApiResponse(false, 404, [
                         'message' => 'Board not found for the provided token'
                     ]);
                 }
+
+                ServiceLocator::get('LogService')->log(
+                    "Board {$pipeline->name} fetched by {$apiTokenRepository->getApiTokenName($cachedDbToken)}",
+                    [
+                        'type'          => WP_QT_LOG_TYPE_PIPELINE,
+                        'type_id'       => $pipeline->id,
+                        'pipeline_id'   => $pipeline->id,
+                        'created_by'    => WP_QT_LOG_CREATED_BY_API_TOKEN,
+                        'created_by_id' => $cachedDbToken->id,
+                    ]
+                );
 
                 return $responseService->createTokenApiResponse(true, 200, [
                     'board' => $pipeline
@@ -139,11 +151,23 @@ function wpqt_register_token_api_routes()
             try {
                 $cachedDbToken = ServiceLocator::get('ApiTokenService')->getRequestTokenCache(WP_QUICKTASKER_CACHED_API_DB_TOKEN);
                 $responseService = ServiceLocator::get('ResponseService');
+                $apiTokenRepository = ServiceLocator::get('ApiTokenRepository');
                 $stages = ServiceLocator::get('StageRepository')->getStagesByPipelineId($cachedDbToken->pipeline_id);
 
                 if (null === $stages) {
                     throw new \Exception('No stages found for the board associated with the provided token.');
                 }
+
+                ServiceLocator::get('LogService')->log(
+                    "Board stages fetched by {$apiTokenRepository->getApiTokenName($cachedDbToken)}",
+                    [
+                        'type'          => WP_QT_LOG_TYPE_PIPELINE,
+                        'type_id'       => $cachedDbToken->pipeline_id,
+                        'pipeline_id'   => $cachedDbToken->pipeline_id,
+                        'created_by'    => WP_QT_LOG_CREATED_BY_API_TOKEN,
+                        'created_by_id' => $cachedDbToken->id,
+                    ]
+                );
 
                 return $responseService->createTokenApiResponse(true, 200, [
                     'stages' => $stages
@@ -346,7 +370,19 @@ function wpqt_register_token_api_routes()
             try {
                 $cachedDbToken = ServiceLocator::get('ApiTokenService')->getRequestTokenCache(WP_QUICKTASKER_CACHED_API_DB_TOKEN);
                 $responseService = ServiceLocator::get('ResponseService');
+                $apiTokenRepository = ServiceLocator::get('ApiTokenRepository');
                 $tasks = ServiceLocator::get('TaskRepository')->getTasks(['pipeline_id' => $cachedDbToken->pipeline_id, 'is_archived' => false]);
+
+                ServiceLocator::get('LogService')->log(
+                    "Board tasks fetched by {$apiTokenRepository->getApiTokenName($cachedDbToken)}",
+                    [
+                        'type'          => WP_QT_LOG_TYPE_PIPELINE,
+                        'type_id'       => $cachedDbToken->pipeline_id,
+                        'pipeline_id'   => $cachedDbToken->pipeline_id,
+                        'created_by'    => WP_QT_LOG_CREATED_BY_API_TOKEN,
+                        'created_by_id' => $cachedDbToken->id,
+                    ]
+                );
 
                 return $responseService->createTokenApiResponse(true, 200, [
                     'tasks' => $tasks

--- a/php/repositories/LogRepository.php
+++ b/php/repositories/LogRepository.php
@@ -158,10 +158,15 @@ if (!class_exists('WPQT\Log\LogRepository')) {
             }
 
             $sql .= ' ORDER BY logs.created_at ' . $order;
-            $sql .= ' LIMIT %d';
-            $queryParams[] = (int) $numberOfLogs;
 
-            $results = $wpdb->get_results($wpdb->prepare($sql, ...$queryParams));
+            if (null !== $numberOfLogs) {
+                $sql .= ' LIMIT %d';
+                $queryParams[] = (int) $numberOfLogs;
+            }
+
+            $results = empty($queryParams)
+                ? $wpdb->get_results($sql)
+                : $wpdb->get_results($wpdb->prepare($sql, ...$queryParams));
 
             return $results;
         }

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,7 @@ QuickTasker is a plugin that offers the following and more to organize your proj
 
 = 1.55.0 =
 * Added a Public Task Form Gutenberg block that lets visitors submit tasks to a selected board from any page.
+* Fixed an issue where the automation, webhook and API token logs modals showed no entries.
 
 = 1.54.0 =
 * Added board notifications.


### PR DESCRIPTION
- Fixed an issue where the automation, webhook and API token logs modals (and the global Logs page "All" filter) returned no entries. LogRepository::getGlobalLogs() was unconditionally appending LIMIT %d and binding (int) null = 0, producing LIMIT 0. The clause is now only appended when numberOfLogs is provided.
- Added log entries for the GET endpoints in token-api.php (/token/board, /token/board/stages, /token/board/tasks) so read-only API token usage is also recorded and surfaced in the per-token logs modal.