### PR TITLE
284 my tasks page

### DIFF
--- a/help/index.html
+++ b/help/index.html
@@ -51,6 +51,7 @@
 			<li><a href="#board">Board</a></li>
 			<li><a href="#task">Task</a></li>
 			<li><a href="#archive">Archive</a></li>
+			<li><a href="#my-tasks">My Tasks</a></li>
 			<li><a href="#users">Users</a></li>
 			<li><a href="#user-page">Tasks page</a></li>
 			<li><a href="#user-sessions">Quicktasker user sessions</a></li>
@@ -64,7 +65,7 @@
 		<hr>
 
 		<h3 id="admin-area"><strong>A) Admin areas</strong> - <a href="#toc">top</a></h3>
-		<p>This plugin provides admin areas accessible to WordPress users who have the required permissions. In the admin areas, users can manage boards, tasks, users etc. Currently there are 7 permissions a WordPress user can have and admins have all of them by default.</p>
+		<p>This plugin provides admin areas accessible to WordPress users who have the required permissions. In the admin areas, users can manage boards, tasks, users etc. Currently there are 8 permissions a WordPress user can have and admins have all of them by default.</p>
 
 		<strong>quicktasker_admin_role</strong>
 		<p>Provides access to admin areas.</p>
@@ -86,6 +87,9 @@
 
 		<strong>quicktasker_admin_role_manage_quicktasker_sessions</strong>
 		<p>Provides access to Quicktasker sessions page to manage QuickTasker type user sessions.</p>
+
+		<strong>quicktasker_view_my_tasks</strong>
+		<p>Provides access to the My Tasks page where the user can view tasks they created and tasks assigned to them.</p>
 
 		<hr>
 		
@@ -140,8 +144,22 @@
 		<p>Archive page allows you to view all archived tasks. Archived tasks can be restored or deleted.</p>
 
 		<hr>
-		
-		<h3 id="users"><strong>E) Users</strong> - <a href="#toc">top</a></h3>
+
+		<h3 id="my-tasks"><strong>E) My Tasks</strong> - <a href="#toc">top</a></h3>
+
+		<p>My Tasks page is a personal overview for the currently logged-in WordPress user. It lists tasks the user has created and tasks that are assigned to them, across all boards. Access is gated by the <strong>quicktasker_view_my_tasks</strong> capability — users with only this capability can use the page without needing full admin access.</p>
+
+		<ul>
+			<li><strong>Tasks I created:</strong> All non-archived tasks the user created from the admin board view.</li>
+			<li><strong>Tasks assigned to me:</strong> All non-archived tasks where the user is an assignee. This section is only shown to users who also have admin access.</li>
+			<li><strong>Board filter:</strong> Narrows both sections to a single board.</li>
+			<li><strong>Search:</strong> Filters by task name or description.</li>
+			<li>Each task card links back to its board for quick navigation.</li>
+		</ul>
+
+		<hr>
+
+		<h3 id="users"><strong>F) Users</strong> - <a href="#toc">top</a></h3>
 		
 		<p>This plugin supports three types of users: WordPress admins, other WordPress users, and special users called quicktaskers. WordPress admins have full access to all admin areas. Other WordPress users do not have any access by default but can be granted if needed. QuickTaskers are separate users who do not have admin access but can manage tasks through special webpage.</p>
 		

--- a/languages/quicktasker.pot
+++ b/languages/quicktasker.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPLv2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: QuickTasker 1.55.0\n"
+"Project-Id-Version: QuickTasker 1.56.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/quicktasker\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-15T11:02:59+00:00\n"
+"POT-Creation-Date: 2026-05-15T16:38:17+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: quicktasker\n"
@@ -48,31 +48,37 @@ msgstr ""
 
 #: php/admin-pages.php:40
 #: php/admin-pages.php:41
+#: build/app.js:1
+msgid "My Tasks"
+msgstr ""
+
+#: php/admin-pages.php:49
+#: php/admin-pages.php:50
 #: php/templates/user-page-app-root.php:11
 #: build/app.js:1
 msgid "Tasks app"
 msgstr ""
 
-#: php/admin-pages.php:49
-#: php/admin-pages.php:50
-#: build/app.js:1
-msgid "Quicktasker sessions"
-msgstr ""
-
 #: php/admin-pages.php:58
 #: php/admin-pages.php:59
 #: build/app.js:1
-msgid "Archive"
+msgid "Quicktasker sessions"
 msgstr ""
 
 #: php/admin-pages.php:67
 #: php/admin-pages.php:68
 #: build/app.js:1
-msgid "Logs"
+msgid "Archive"
 msgstr ""
 
 #: php/admin-pages.php:76
 #: php/admin-pages.php:77
+#: build/app.js:1
+msgid "Logs"
+msgstr ""
+
+#: php/admin-pages.php:85
+#: php/admin-pages.php:86
 #: build/app.js:1
 msgid "About"
 msgstr ""
@@ -85,69 +91,69 @@ msgid "Stage was changed for task \"%s\""
 msgstr ""
 
 #. translators: %s = task name
-#: php/api/admin-api.php:876
+#: php/api/admin-api.php:878
 #, php-format
 msgid "Due date for task \"%s\" changed"
 msgstr ""
 
 #. translators: %s = task name
-#: php/api/admin-api.php:988
+#: php/api/admin-api.php:990
 #, php-format
 msgid "Task \"%s\" was deleted"
 msgstr ""
 
 #. translators: %s = task name
-#: php/api/admin-api.php:1078
+#: php/api/admin-api.php:1080
 #, php-format
 msgid "Task \"%s\" was archived"
 msgstr ""
 
 #. translators: %s = task name
-#: php/api/admin-api.php:1171
+#: php/api/admin-api.php:1173
 #, php-format
 msgid "Task \"%s\" was restored from the archive"
 msgstr ""
 
 #. translators: %s = task name
-#: php/api/admin-api.php:1276
+#: php/api/admin-api.php:1278
 #: php/api/user-page-api.php:974
 #, php-format
 msgid "Task \"%s\" was marked done"
 msgstr ""
 
 #. translators: %s = task name
-#: php/api/admin-api.php:1278
+#: php/api/admin-api.php:1280
 #: php/api/user-page-api.php:976
 #, php-format
 msgid "Task \"%s\" was marked not done"
 msgstr ""
 
 #. translators: %1$s = assigner name, %2$s = task name
-#: php/api/admin-api.php:1899
+#: php/api/admin-api.php:1931
 #, php-format
 msgid "%1$s assigned you to task \"%2$s\""
 msgstr ""
 
 #. translators: %1$s = unassigner name, %2$s = task name
-#: php/api/admin-api.php:2023
+#: php/api/admin-api.php:2055
 #, php-format
 msgid "%1$s unassigned you from task \"%2$s\""
 msgstr ""
 
 #. translators: %s = task name
-#: php/api/admin-api.php:2650
+#: php/api/admin-api.php:2688
 #, php-format
 msgid "A private comment was added to task \"%s\""
 msgstr ""
 
 #. translators: %s = task name
-#: php/api/admin-api.php:2652
+#: php/api/admin-api.php:2690
 #: php/api/user-page-api.php:437
 #, php-format
 msgid "A public comment was added to task \"%s\""
 msgstr ""
 
-#: php/api/admin-api.php:3119
+#: php/api/admin-api.php:3157
 msgid "No valid settings provided"
 msgstr ""
 
@@ -278,7 +284,7 @@ msgstr ""
 msgid "Not set"
 msgstr ""
 
-#: php/services/TaskService.php:450
+#: php/services/TaskService.php:454
 msgid "Cannot restore the task. The selected board needs at least one stage."
 msgstr ""
 
@@ -1633,6 +1639,40 @@ msgid "The logs page where you can see all logs and filter them."
 msgstr ""
 
 #: build/app.js:1
+msgid "Tasks you have created and tasks assigned to you."
+msgstr ""
+
+#: build/app.js:1
+msgid "Search tasks"
+msgstr ""
+
+#: build/app.js:1
+msgid "Tasks I created"
+msgstr ""
+
+#: build/app.js:1
+msgid "You haven't created any tasks yet."
+msgstr ""
+
+#: build/app.js:1
+msgid "Tasks assigned to me"
+msgstr ""
+
+#: build/app.js:1
+msgid "No tasks assigned to you."
+msgstr ""
+
+#: build/app.js:1
+msgid "Done"
+msgstr ""
+
+#: build/app.js:1
+#: build/publicTaskBlock.js:1
+#: build/publicTaskBlockView.js:1
+msgid "In progress"
+msgstr ""
+
+#: build/app.js:1
 msgid "Pie"
 msgstr ""
 
@@ -2278,11 +2318,15 @@ msgid "Access to archive page"
 msgstr ""
 
 #: build/app.js:1
+msgid "Allow access to Tasks App"
+msgstr ""
+
+#: build/app.js:1
 msgid "Allow to delete resources"
 msgstr ""
 
 #: build/app.js:1
-msgid "Allow access to user tasks app"
+msgid "Access to My Tasks page"
 msgstr ""
 
 #: build/app.js:1
@@ -2518,11 +2562,6 @@ msgstr ""
 #: build/publicTaskBlock.js:1
 #: build/publicTaskBlockView.js:1
 msgid "This task is no longer available."
-msgstr ""
-
-#: build/publicTaskBlock.js:1
-#: build/publicTaskBlockView.js:1
-msgid "In progress"
 msgstr ""
 
 #: build/publicTaskBlock.js:1

--- a/php/admin-pages.php
+++ b/php/admin-pages.php
@@ -37,6 +37,15 @@ if (!function_exists('wp_quick_taks_add_admin_menu')) {
 
         add_submenu_page(
             'wp-quicktasker',
+            esc_html__('My Tasks', 'quicktasker'),
+            esc_html__('My Tasks', 'quicktasker'),
+            WP_QUICKTASKER_VIEW_MY_TASKS,
+            'wp-quicktasker-my-tasks',
+            'wp_quick_taks_generate_app_page'
+        );
+
+        add_submenu_page(
+            'wp-quicktasker',
             esc_html__('Tasks app', 'quicktasker'),
             esc_html__('Tasks app', 'quicktasker'),
             WP_QUICKTASKER_ACCESS_USER_PAGE_APP,

--- a/php/api/admin-api.php
+++ b/php/api/admin-api.php
@@ -1867,6 +1867,34 @@ if (!function_exists('wpqt_register_api_routes')) {
                             ? $taskRepo->getTasksAssignedToUser($userId, false, WP_QT_WORDPRESS_USER_TYPE)
                             : null;
 
+                        $allTasks = array_merge($created, $assigned ?: []);
+                        $taskIds = array_map(function ($t) {
+                            return $t->id;
+                        }, $allTasks);
+                        $labelsByTask = [];
+                        $usersByTask = [];
+                        $wpUsersByTask = [];
+                        if (!empty($taskIds)) {
+                            $labels = ServiceLocator::get('LabelRepository')->getAssignedLabelsByTaskIds($taskIds);
+                            foreach ($labels as $label) {
+                                $labelsByTask[$label->entity_id][] = $label;
+                            }
+                            $userRepository = ServiceLocator::get('UserRepository');
+                            $assignedUsers = $userRepository->getAssignedUsersByTaskIds($taskIds);
+                            foreach ($assignedUsers as $user) {
+                                $usersByTask[$user->task_id][] = $user;
+                            }
+                            $assignedWPUsers = $userRepository->getAssignedWPUsersByTaskIds($taskIds);
+                            foreach ($assignedWPUsers as $user) {
+                                $wpUsersByTask[$user->task_id][] = $user;
+                            }
+                        }
+                        foreach ($allTasks as $task) {
+                            $task->assigned_labels = isset($labelsByTask[$task->id]) ? $labelsByTask[$task->id] : [];
+                            $task->assigned_users = isset($usersByTask[$task->id]) ? $usersByTask[$task->id] : [];
+                            $task->assigned_wp_users = isset($wpUsersByTask[$task->id]) ? $wpUsersByTask[$task->id] : [];
+                        }
+
                         return new WP_REST_Response((new ApiResponse(true, [], (object) [
                             'created'  => $created,
                             'assigned' => $assigned,

--- a/php/api/admin-api.php
+++ b/php/api/admin-api.php
@@ -723,8 +723,10 @@ if (!function_exists('wpqt_register_api_routes')) {
                         $stageService->validateStageAndPipeline($data['stageId'], $data['pipelineId']);
 
                         $newTask = $taskService->createTask($data['stageId'], [
-                            'name'       => $data['name'],
-                            'pipelineId' => $data['pipelineId'],
+                            'name'            => $data['name'],
+                            'pipelineId'      => $data['pipelineId'],
+                            'created_by_id'   => $userId,
+                            'created_by_type' => WP_QT_WORDPRESS_USER_TYPE,
                         ]);
                         $logService->log('Task ' . $newTask->name . ' created', [
                             'type'          => WP_QT_LOG_TYPE_TASK,
@@ -1851,6 +1853,36 @@ if (!function_exists('wpqt_register_api_routes')) {
 
         register_rest_route(
             'wpqt/v1',
+            'my-tasks',
+            [
+                'methods'  => 'GET',
+                'callback' => function () {
+                    try {
+                        $userId = get_current_user_id();
+                        $taskRepo = ServiceLocator::get('TaskRepository');
+
+                        $created = $taskRepo->getTasksCreatedByUser($userId, WP_QT_WORDPRESS_USER_TYPE);
+                        $hasAdminAccess = current_user_can(WP_QUICKTASKER_ADMIN_ROLE);
+                        $assigned = $hasAdminAccess
+                            ? $taskRepo->getTasksAssignedToUser($userId, false, WP_QT_WORDPRESS_USER_TYPE)
+                            : null;
+
+                        return new WP_REST_Response((new ApiResponse(true, [], (object) [
+                            'created'  => $created,
+                            'assigned' => $assigned,
+                        ]))->toArray(), 200);
+                    } catch (Throwable $e) {
+                        return ServiceLocator::get('ErrorHandlerService')->handlePrivateApiError($e);
+                    }
+                },
+                'permission_callback' => function () {
+                    return PermissionService::hasRequiredPermissionsForMyTasks();
+                },
+            ],
+        );
+
+        register_rest_route(
+            'wpqt/v1',
             'users/(?P<id>\d+)/tasks/(?P<task_id>\d+)',
             [
                 'methods'  => 'POST',
@@ -2384,6 +2416,7 @@ if (!function_exists('wpqt_register_api_routes')) {
                             WP_QUICKTASKER_ADMIN_ROLE_MANAGE_SETTINGS => $data[WP_QUICKTASKER_ADMIN_ROLE_MANAGE_SETTINGS],
                             WP_QUICKTASKER_ADMIN_ROLE_MANAGE_ARCHIVE  => $data[WP_QUICKTASKER_ADMIN_ROLE_MANAGE_ARCHIVE],
                             WP_QUICKTASKER_ACCESS_USER_PAGE_APP       => $data[WP_QUICKTASKER_ACCESS_USER_PAGE_APP],
+                            WP_QUICKTASKER_VIEW_MY_TASKS              => $data[WP_QUICKTASKER_VIEW_MY_TASKS],
                         ];
 
                         $capabilityService->updateWPUserCapabilities($data['id'], $capabilities);
@@ -2423,6 +2456,11 @@ if (!function_exists('wpqt_register_api_routes')) {
                         'sanitize_callback' => ['WPQT\RequestValidation', 'sanitizeBooleanParam'],
                     ],
                     WP_QUICKTASKER_ACCESS_USER_PAGE_APP => [
+                        'required'          => true,
+                        'validate_callback' => ['WPQT\RequestValidation', 'validateBooleanParam'],
+                        'sanitize_callback' => ['WPQT\RequestValidation', 'sanitizeBooleanParam'],
+                    ],
+                    WP_QUICKTASKER_VIEW_MY_TASKS => [
                         'required'          => true,
                         'validate_callback' => ['WPQT\RequestValidation', 'validateBooleanParam'],
                         'sanitize_callback' => ['WPQT\RequestValidation', 'sanitizeBooleanParam'],

--- a/php/api/admin-api.php
+++ b/php/api/admin-api.php
@@ -1862,7 +1862,7 @@ if (!function_exists('wpqt_register_api_routes')) {
                         $taskRepo = ServiceLocator::get('TaskRepository');
 
                         $created = $taskRepo->getTasksCreatedByUser($userId, WP_QT_WORDPRESS_USER_TYPE);
-                        $hasAdminAccess = current_user_can(WP_QUICKTASKER_ADMIN_ROLE);
+                        $hasAdminAccess = PermissionService::hasRequiredPermissionsForPrivateAPI();
                         $assigned = $hasAdminAccess
                             ? $taskRepo->getTasksAssignedToUser($userId, false, WP_QT_WORDPRESS_USER_TYPE)
                             : null;

--- a/php/api/public-api.php
+++ b/php/api/public-api.php
@@ -22,10 +22,6 @@ if (!function_exists('wpqt_register_public_api_routes')) {
 
                     $publicTaskService = ServiceLocator::get('PublicTaskService');
                     $publicTaskService->ensureCanCreatePublicTask($data['pipeline_id']);
-                    $task = $publicTaskService->createPublicTask($data['pipeline_id'], [
-                        'name'        => $data['name'],
-                        'description' => $data['description'],
-                    ]);
 
                     if (is_user_logged_in()) {
                         $createdBy = current_user_can('manage_options')
@@ -36,6 +32,13 @@ if (!function_exists('wpqt_register_public_api_routes')) {
                         $createdBy = WP_QT_LOG_CREATED_BY_ANONYMOUS;
                         $createdById = null;
                     }
+
+                    $task = $publicTaskService->createPublicTask($data['pipeline_id'], [
+                        'name'            => $data['name'],
+                        'description'     => $data['description'],
+                        'created_by_id'   => $createdById,
+                        'created_by_type' => $createdById ? WP_QT_WORDPRESS_USER_TYPE : null,
+                    ]);
                     ServiceLocator::get('LogService')->log('Public submission: task ' . $task->name . ' created', [
                         'type'          => WP_QT_LOG_TYPE_TASK,
                         'type_id'       => $task->id,

--- a/php/constants.php
+++ b/php/constants.php
@@ -60,7 +60,7 @@ DB constants
 */
 
 if (!defined('WP_QUICKTASKER_DB_VERSION')) {
-    define('WP_QUICKTASKER_DB_VERSION', '1.60.0');
+    define('WP_QUICKTASKER_DB_VERSION', '1.61.0');
 }
 
 if (!defined('TABLE_WP_QUICKTASKER_USERS')) {
@@ -381,7 +381,7 @@ if (!defined('WP_QUICKTASKER_INVALID_SESSION_TOKEN')) {
 }
 
 if (!defined('WP_QUICKTASKER_SIDE_EFFECT_TRIGGER')) {
-    define('WP_QUICKTASKER_SIDE_EFFECT_TRIGGER', '9');
+    define('WP_QUICKTASKER_SIDE_EFFECT_TRIGGER', '10');
 }
 
 if (!defined('WP_QUICKTASKER_DB_SEEDER_TRIGGER')) {
@@ -424,6 +424,10 @@ if (!defined('WP_QUICKTASKER_ACCESS_USER_PAGE_APP')) {
 
 if (!defined('WP_QUICKTASKER_ADMIN_ROLE_MANAGE_QUICKTASKER_SESSIONS')) {
     define('WP_QUICKTASKER_ADMIN_ROLE_MANAGE_QUICKTASKER_SESSIONS', 'quicktasker_admin_role_manage_quicktasker_sessions'); // Allows access to QuickTasker user sessions page and related private API endpoints
+}
+
+if (!defined('WP_QUICKTASKER_VIEW_MY_TASKS')) {
+    define('WP_QUICKTASKER_VIEW_MY_TASKS', 'quicktasker_view_my_tasks'); // Allows access to the My Tasks page and related private API endpoint
 }
 
 /*

--- a/php/db.php
+++ b/php/db.php
@@ -62,11 +62,14 @@ if (!function_exists('wpqt_set_up_db')) {
 				task_hash varchar(255) NOT NULL,
 				task_focus_color varchar(255) DEFAULT NULL,
 				is_public_submission tinyint(1) NOT NULL DEFAULT 0,
+				created_by_id int(11) DEFAULT NULL,
+				created_by_type ENUM('wp-user','quicktasker') DEFAULT NULL,
 				PRIMARY KEY  (id),
 				UNIQUE KEY task_hash (task_hash),
 				INDEX pipeline_id (pipeline_id),
 				INDEX is_archived (is_archived),
-				INDEX is_public_submission (is_public_submission)
+				INDEX is_public_submission (is_public_submission),
+				INDEX created_by (created_by_type, created_by_id)
 			) $charset_collate;";
 
             dbDelta($sql3);

--- a/php/repositories/TaskRepository.php
+++ b/php/repositories/TaskRepository.php
@@ -339,9 +339,11 @@ if (!class_exists('WPQT\Task\TaskRepository')) {
                 $userId
             )); */
 
-            $sql = 'SELECT b.*, c.name as pipeline_name FROM ' . TABLE_WP_QUICKTASKER_USER_TASK . ' AS a
+            $sql = 'SELECT b.*, c.name as pipeline_name, e.name as stage_name FROM ' . TABLE_WP_QUICKTASKER_USER_TASK . ' AS a
                 LEFT JOIN ' . TABLE_WP_QUICKTASKER_TASKS . ' AS b ON a.task_id = b.id
                 LEFT JOIN ' . TABLE_WP_QUICKTASKER_PIPELINES . ' AS c ON b.pipeline_id = c.id
+                LEFT JOIN ' . TABLE_WP_QUICKTASKER_TASKS_LOCATION . ' AS d ON b.id = d.task_id
+                LEFT JOIN ' . TABLE_WP_QUICKTASKER_PIPELINE_STAGES . ' AS e ON d.stage_id = e.id
                 WHERE a.user_id = %d';
             $args = [$userId];
 
@@ -362,6 +364,34 @@ if (!class_exists('WPQT\Task\TaskRepository')) {
             }
 
             return $tasks;
+        }
+
+        /**
+         * Retrieves tasks created by a specific user.
+         *
+         * @param int $userId The ID of the user.
+         * @param string $userType The creator type ('wp-user' or 'quicktasker').
+         * @return array Tasks created by the user.
+         */
+        public function getTasksCreatedByUser($userId, $userType = WP_QT_WORDPRESS_USER_TYPE)
+        {
+            global $wpdb;
+
+            return $wpdb->get_results($wpdb->prepare(
+                'SELECT a.id, a.pipeline_id, a.name, a.description, a.is_archived, a.is_done,
+                        a.free_for_all, a.created_at, a.updated_at, a.due_date, a.task_completed_at,
+                        a.task_hash, a.task_focus_color, a.is_public_submission,
+                        a.created_by_id, a.created_by_type,
+                        c.name as pipeline_name, e.name as stage_name
+                FROM ' . TABLE_WP_QUICKTASKER_TASKS . ' AS a
+                LEFT JOIN ' . TABLE_WP_QUICKTASKER_PIPELINES . ' AS c ON a.pipeline_id = c.id
+                LEFT JOIN ' . TABLE_WP_QUICKTASKER_TASKS_LOCATION . ' AS d ON a.id = d.task_id
+                LEFT JOIN ' . TABLE_WP_QUICKTASKER_PIPELINE_STAGES . ' AS e ON d.stage_id = e.id
+                WHERE a.created_by_id = %d AND a.created_by_type = %s AND a.is_archived = 0
+                ORDER BY a.created_at DESC',
+                $userId,
+                $userType
+            ));
         }
 
         /**

--- a/php/services/CapabilityService.php
+++ b/php/services/CapabilityService.php
@@ -57,6 +57,10 @@ if (!class_exists('WPQT\Capability\CapabilityService')) {
             if (!$adminRole->has_cap(WP_QUICKTASKER_ADMIN_ROLE_MANAGE_QUICKTASKER_SESSIONS)) {
                 $adminRole->add_cap(WP_QUICKTASKER_ADMIN_ROLE_MANAGE_QUICKTASKER_SESSIONS);
             }
+
+            if (!$adminRole->has_cap(WP_QUICKTASKER_VIEW_MY_TASKS)) {
+                $adminRole->add_cap(WP_QUICKTASKER_VIEW_MY_TASKS);
+            }
         }
 
         /**
@@ -105,6 +109,10 @@ if (!class_exists('WPQT\Capability\CapabilityService')) {
 
             if ($adminRole->has_cap(WP_QUICKTASKER_ADMIN_ROLE_MANAGE_QUICKTASKER_SESSIONS)) {
                 $adminRole->remove_cap(WP_QUICKTASKER_ADMIN_ROLE_MANAGE_QUICKTASKER_SESSIONS);
+            }
+
+            if ($adminRole->has_cap(WP_QUICKTASKER_VIEW_MY_TASKS)) {
+                $adminRole->remove_cap(WP_QUICKTASKER_VIEW_MY_TASKS);
             }
         }
 

--- a/php/services/LocationService.php
+++ b/php/services/LocationService.php
@@ -16,7 +16,7 @@ if (!class_exists('WPQT\Location\LocationService')) {
          */
         public function isWPQTPage()
         {
-            if (isset($_GET['page']) && 'wp-quicktasker' === $_GET['page']) {
+            if (isset($_GET['page']) && in_array($_GET['page'], ['wp-quicktasker', 'wp-quicktasker-my-tasks'], true)) {
                 return true;
             }
 

--- a/php/services/PermissionService.php
+++ b/php/services/PermissionService.php
@@ -100,6 +100,16 @@ if (!class_exists('WPQT\Permission\PermissionService')) {
         }
 
         /**
+         * Checks if the current user has the required permissions to view the My Tasks page.
+         *
+         * @return bool True if the user has the required permissions, false otherwise.
+         */
+        public static function hasRequiredPermissionsForMyTasks()
+        {
+            return current_user_can(WP_QUICKTASKER_VIEW_MY_TASKS);
+        }
+
+        /**
          * Checks if a user is allowed to view a task.
          *
          * @param int $userId The ID of the user.

--- a/php/services/PublicTaskService.php
+++ b/php/services/PublicTaskService.php
@@ -77,6 +77,8 @@ if (!class_exists('WPQT\PublicTask\PublicTaskService')) {
                 'description'          => $description,
                 'pipelineId'           => $pipelineId,
                 'is_public_submission' => 1,
+                'created_by_id'        => isset($args['created_by_id']) ? $args['created_by_id'] : null,
+                'created_by_type'      => isset($args['created_by_type']) ? $args['created_by_type'] : null,
             ]);
 
             ServiceLocator::get('SettingRepository')->incrementPublicTaskCount($pipelineId);

--- a/php/services/TaskService.php
+++ b/php/services/TaskService.php
@@ -53,7 +53,9 @@ if (!class_exists('WPQT\Task\TaskService')) {
                 'is_archived'          => 0,
                 'task_completed_at'    => null,
                 'is_done'              => 0,
-                'is_public_submission' => 0
+                'is_public_submission' => 0,
+                'created_by_id'        => null,
+                'created_by_type'      => null
             ];
 
             $args = wp_parse_args($args, $defaults);
@@ -74,7 +76,9 @@ if (!class_exists('WPQT\Task\TaskService')) {
                 'is_archived'          => $args['is_archived'],
                 'task_completed_at'    => $args['task_completed_at'],
                 'is_done'              => $args['is_done'],
-                'is_public_submission' => $args['is_public_submission']
+                'is_public_submission' => $args['is_public_submission'],
+                'created_by_id'        => $args['created_by_id'],
+                'created_by_type'      => $args['created_by_type']
             ]);
 
             if (false === $result) {

--- a/quicktasker.php
+++ b/quicktasker.php
@@ -7,7 +7,7 @@
     Author URI: https://github.com/SiimKirjanen
     Text Domain: quicktasker
     Domain Path: /languages
-    Version: 1.55.0
+    Version: 1.56.0
     Requires at least: 5.3
     Requires PHP: 7.2.28
     License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: task manager, task management, project manager, project management, task b
 Requires at least: 5.3
 Requires PHP: 7.2.28
 Tested up to: 6.9.0
-Stable tag: 1.55.0
+Stable tag: 1.56.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -48,6 +48,9 @@ QuickTasker is a plugin that offers the following and more to organize your proj
 
 
 == Changelog ==
+
+= 1.56.0 =
+* Added a "My Tasks" admin page that lists tasks the current user created and tasks assigned to them, gated by a new "Access to My Tasks page" capability.
 
 = 1.55.0 =
 * Added a Public Task Form Gutenberg block that lets visitors submit tasks to a selected board from any page.

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -580,6 +580,16 @@ function getUserTasksRequest(
   });
 }
 
+function getMyTasksRequest(): Promise<
+  WPQTResponse<{ created: TaskFromServer[]; assigned: TaskFromServer[] }>
+> {
+  return apiFetch({
+    path: `/wpqt/v1/my-tasks`,
+    method: "GET",
+    headers: getCommonHeaders(),
+  });
+}
+
 function resetUserPasswordRequest(userId: string): Promise<WPQTResponse> {
   return apiFetch({
     path: `/wpqt/v1/users/${userId}/password-reset`,
@@ -615,6 +625,7 @@ function updateWPUserPermissionsRequest(
         capabilities.quicktasker_admin_role_manage_archive,
       quicktasker_access_user_page_app:
         capabilities.quicktasker_access_user_page_app,
+      quicktasker_view_my_tasks: capabilities.quicktasker_view_my_tasks,
     },
     headers: getCommonHeaders(),
   });
@@ -1191,6 +1202,7 @@ export {
   getExtendedUserRequest,
   getGlobalLogsRequest,
   getLogsRequest,
+  getMyTasksRequest,
   getNotificationsRequest,
   getPipelineApiTokensRequest,
   getPipelineAutomationsRequest,

--- a/src/hooks/useCurrentPage.tsx
+++ b/src/hooks/useCurrentPage.tsx
@@ -88,8 +88,6 @@ const getPageFromUrl = () => {
     }
 
     switch (hash) {
-      case "#/my-tasks":
-        return <MyTasksPage />;
       case "#/user-management":
         return <UserManagement />;
       case "#/archive":
@@ -111,7 +109,7 @@ const getPageFromUrl = () => {
 const setSubMenuItemActive = () => {
   const { page, hash } = getUrlParams();
 
-  if (page !== "wp-quicktasker") {
+  if (page !== "wp-quicktasker" && page !== "wp-quicktasker-my-tasks") {
     return;
   }
 
@@ -120,35 +118,38 @@ const setSubMenuItemActive = () => {
   );
   submenuItems.forEach((item) => item.classList.remove("wpqt-current"));
 
-  const hashMap: { [key: string]: string } = {
-    "#/my-tasks": "#/my-tasks",
-    "#/user-management": "#/user-management",
-    "#/overview": "#/overview",
-    "#/archive": "#/archive",
-    "#/quicktasker-sessions": "#/quicktasker-sessions",
-    "#/tasks-app-settings": "#/tasks-app-settings",
-    "#/logs": "#/logs",
-    "#/settings": "#/settings",
-    "#/about": "#/about",
-    default: "",
-  };
+  let targetHref: string | null = null;
 
-  let targetHash = hashMap.default;
+  if (page === "wp-quicktasker-my-tasks") {
+    targetHref = "admin.php?page=wp-quicktasker-my-tasks";
+  } else {
+    const hashMap: { [key: string]: string } = {
+      "#/user-management": "#/user-management",
+      "#/overview": "#/overview",
+      "#/archive": "#/archive",
+      "#/quicktasker-sessions": "#/quicktasker-sessions",
+      "#/tasks-app-settings": "#/tasks-app-settings",
+      "#/logs": "#/logs",
+      "#/settings": "#/settings",
+      "#/about": "#/about",
+      default: "",
+    };
 
-  if (hashMap[hash] !== undefined) {
-    targetHash = hashMap[hash];
-  } else if (/^#\/user-management(\/\d+)?(\/tasks)?$/.test(hash)) {
-    targetHash = "#/user-management";
+    let targetHash = hashMap.default;
+
+    if (hashMap[hash] !== undefined) {
+      targetHash = hashMap[hash];
+    } else if (/^#\/user-management(\/\d+)?(\/tasks)?$/.test(hash)) {
+      targetHash = "#/user-management";
+    }
+
+    targetHref = `admin.php?page=wp-quicktasker${targetHash}`;
   }
 
   submenuItems.forEach((item) => {
     const link = item.querySelector("a");
 
-    if (
-      link &&
-      link.getAttribute("href") &&
-      link.getAttribute("href") === `admin.php?page=wp-quicktasker${targetHash}`
-    ) {
+    if (link && link.getAttribute("href") === targetHref) {
       item.classList.add("wpqt-current");
     }
   });

--- a/src/hooks/useCurrentPage.tsx
+++ b/src/hooks/useCurrentPage.tsx
@@ -4,6 +4,7 @@ import { ArchivePage } from "../pages/ArchivePage/ArchivePage";
 import { AutomationsPage } from "../pages/AutomationsPage/AutomationsPage";
 import { GuidePage } from "../pages/GuidePage/GuidePage";
 import { LogsPage } from "../pages/LogsPage/LogsPage";
+import { MyTasksPage } from "../pages/MyTasksPage/MyTasksPage";
 import { OverviewPage } from "../pages/OverviewPage/OverviewPage";
 import { PipelinePage } from "../pages/PipelinePage/PipelinePage";
 import { UserAppPage } from "../pages/UserAppPage/UserAppPage";
@@ -38,6 +39,10 @@ const useCurrentPage = () => {
 
 const getPageFromUrl = () => {
   const { page, hash } = getUrlParams();
+
+  if (page === "wp-quicktasker-my-tasks") {
+    return <MyTasksPage />;
+  }
 
   if (page === "wp-quicktasker") {
     const userTasksMatch = hash.match(/^#\/user-management\/(\d+)\/tasks$/);
@@ -83,6 +88,8 @@ const getPageFromUrl = () => {
     }
 
     switch (hash) {
+      case "#/my-tasks":
+        return <MyTasksPage />;
       case "#/user-management":
         return <UserManagement />;
       case "#/archive":
@@ -114,6 +121,7 @@ const setSubMenuItemActive = () => {
   submenuItems.forEach((item) => item.classList.remove("wpqt-current"));
 
   const hashMap: { [key: string]: string } = {
+    "#/my-tasks": "#/my-tasks",
     "#/user-management": "#/user-management",
     "#/overview": "#/overview",
     "#/archive": "#/archive",

--- a/src/pages/MyTasksPage/MyTasksPage.test.tsx
+++ b/src/pages/MyTasksPage/MyTasksPage.test.tsx
@@ -1,0 +1,273 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+import { TaskFromServer } from "../../types/task";
+
+const mockGetMyTasksRequest = jest.fn();
+jest.mock("../../api/api", () => ({
+  getMyTasksRequest: (...args: unknown[]) => mockGetMyTasksRequest(...args),
+}));
+
+jest.mock("../../hooks/useTimezone", () => ({
+  useTimezone: () => ({
+    convertToWPTimezone: (v: string) => v,
+  }),
+}));
+
+jest.mock("../Page/Page", () => ({
+  Page: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock("../../components/Card/Card", () => ({
+  WPQTCard: ({
+    title,
+    description,
+    children,
+  }: {
+    title: string;
+    description?: string;
+    children?: React.ReactNode;
+  }) => (
+    <div data-testid="task-card">
+      <h3>{title}</h3>
+      {description && <p>{description}</p>}
+      {children}
+    </div>
+  ),
+}));
+
+jest.mock("../../components/common/Header/Header", () => ({
+  WPQTPageHeader: ({
+    children,
+    rightSideContent,
+  }: {
+    children: React.ReactNode;
+    rightSideContent?: React.ReactNode;
+  }) => (
+    <div>
+      <h1>{children}</h1>
+      {rightSideContent}
+    </div>
+  ),
+}));
+
+jest.mock("../../components/common/Input/Input", () => ({
+  WPQTInput: ({
+    value,
+    onChange,
+    placeholder,
+  }: {
+    value: string;
+    onChange: (v: string) => void;
+    placeholder?: string;
+  }) => (
+    <input
+      data-testid="search-input"
+      placeholder={placeholder}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+
+jest.mock("../../components/Loading/Loading", () => ({
+  LoadingOval: () => <div data-testid="loading-oval" />,
+}));
+
+import { MyTasksPage } from "./MyTasksPage";
+
+function makeTask(overrides: Partial<TaskFromServer> = {}): TaskFromServer {
+  return {
+    id: "1",
+    pipeline_id: "10",
+    pipeline_name: "Board A",
+    stage_id: "100",
+    stage_name: "In Progress",
+    name: "Sample task",
+    description: "Sample description",
+    task_hash: "hash",
+    created_at: "2026-01-01 10:00:00",
+    assigned_labels: [],
+    due_date: null,
+    task_focus_color: null,
+    task_completed_at: null,
+    task_order: "0",
+    free_for_all: "0",
+    assigned_users: [],
+    assigned_wp_users: [],
+    is_archived: "0",
+    is_done: "0",
+    ...overrides,
+  } as TaskFromServer;
+}
+
+async function renderAndWait(response: {
+  success: boolean;
+  data?: { created: TaskFromServer[]; assigned: TaskFromServer[] | null };
+}) {
+  mockGetMyTasksRequest.mockResolvedValue(response);
+  await act(async () => {
+    render(<MyTasksPage />);
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("MyTasksPage", () => {
+  it("renders both sections when API returns created and assigned arrays", async () => {
+    await renderAndWait({
+      success: true,
+      data: {
+        created: [makeTask({ id: "1", name: "Created A" })],
+        assigned: [makeTask({ id: "2", name: "Assigned A" })],
+      },
+    });
+
+    expect(screen.getByText("Tasks I created")).toBeInTheDocument();
+    expect(screen.getByText("Tasks assigned to me")).toBeInTheDocument();
+    expect(screen.getByText("Created A")).toBeInTheDocument();
+    expect(screen.getByText("Assigned A")).toBeInTheDocument();
+  });
+
+  it("hides the 'Tasks assigned to me' section when assigned is null", async () => {
+    await renderAndWait({
+      success: true,
+      data: {
+        created: [makeTask({ id: "1", name: "Created A" })],
+        assigned: null,
+      },
+    });
+
+    expect(screen.getByText("Tasks I created")).toBeInTheDocument();
+    expect(screen.queryByText("Tasks assigned to me")).not.toBeInTheDocument();
+  });
+
+  it("renders empty-state copy when both sections have no tasks", async () => {
+    await renderAndWait({
+      success: true,
+      data: { created: [], assigned: [] },
+    });
+
+    expect(
+      screen.getByText("You haven't created any tasks yet."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("No tasks assigned to you.")).toBeInTheDocument();
+  });
+
+  it("filters tasks by name via the search input", async () => {
+    await renderAndWait({
+      success: true,
+      data: {
+        created: [
+          makeTask({ id: "1", name: "Alpha task" }),
+          makeTask({ id: "2", name: "Beta task" }),
+        ],
+        assigned: [makeTask({ id: "3", name: "Gamma task" })],
+      },
+    });
+
+    const input = screen.getByTestId("search-input");
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "Alpha" } });
+    });
+
+    expect(screen.getByText("Alpha task")).toBeInTheDocument();
+    expect(screen.queryByText("Beta task")).not.toBeInTheDocument();
+    expect(screen.queryByText("Gamma task")).not.toBeInTheDocument();
+  });
+
+  it("filters tasks by description and tolerates null descriptions", async () => {
+    await renderAndWait({
+      success: true,
+      data: {
+        created: [
+          makeTask({
+            id: "1",
+            name: "T1",
+            description: "matchingKeyword inside",
+          }),
+          makeTask({
+            id: "2",
+            name: "T2",
+            description: null as unknown as string,
+          }),
+        ],
+        assigned: null,
+      },
+    });
+
+    const input = screen.getByTestId("search-input");
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "matchingKeyword" } });
+    });
+
+    expect(screen.getByText("T1")).toBeInTheDocument();
+    expect(screen.queryByText("T2")).not.toBeInTheDocument();
+  });
+
+  it("re-fetches when the refresh icon is clicked", async () => {
+    mockGetMyTasksRequest.mockResolvedValueOnce({
+      success: true,
+      data: { created: [], assigned: [] },
+    });
+    await act(async () => {
+      render(<MyTasksPage />);
+    });
+
+    expect(mockGetMyTasksRequest).toHaveBeenCalledTimes(1);
+
+    mockGetMyTasksRequest.mockResolvedValueOnce({
+      success: true,
+      data: {
+        created: [makeTask({ id: "1", name: "Fresh task" })],
+        assigned: [],
+      },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("refresh-icon"));
+    });
+
+    await waitFor(() => expect(mockGetMyTasksRequest).toHaveBeenCalledTimes(2));
+    expect(screen.getByText("Fresh task")).toBeInTheDocument();
+  });
+
+  it("shows Done with completion date when task is done", async () => {
+    await renderAndWait({
+      success: true,
+      data: {
+        created: [
+          makeTask({
+            id: "1",
+            name: "Done task",
+            is_done: "1",
+            task_completed_at: "2026-02-02 12:00:00",
+          }),
+        ],
+        assigned: null,
+      },
+    });
+
+    expect(screen.getByText("Done: 2026-02-02 12:00:00")).toBeInTheDocument();
+    expect(screen.queryByText("In progress")).not.toBeInTheDocument();
+  });
+
+  it("shows 'In progress' when task is not done", async () => {
+    await renderAndWait({
+      success: true,
+      data: {
+        created: [makeTask({ id: "1", name: "Open task", is_done: "0" })],
+        assigned: null,
+      },
+    });
+
+    expect(screen.getByText("In progress")).toBeInTheDocument();
+  });
+});

--- a/src/pages/MyTasksPage/MyTasksPage.tsx
+++ b/src/pages/MyTasksPage/MyTasksPage.tsx
@@ -1,0 +1,176 @@
+import {
+  ArrowPathIcon,
+  CheckCircleIcon,
+  ClockIcon,
+  MagnifyingGlassIcon,
+} from "@heroicons/react/24/outline";
+import { useEffect, useMemo, useState } from "@wordpress/element";
+import { __ } from "@wordpress/i18n";
+import { getMyTasksRequest } from "../../api/api";
+import { WPQTCard } from "../../components/Card/Card";
+import { WPQTPageHeader } from "../../components/common/Header/Header";
+import { WPQTInput } from "../../components/common/Input/Input";
+import { LoadingOval } from "../../components/Loading/Loading";
+import { useTimezone } from "../../hooks/useTimezone";
+import { TaskFromServer } from "../../types/task";
+import { Page } from "../Page/Page";
+
+type MyTasks = {
+  created: TaskFromServer[];
+  assigned: TaskFromServer[] | null;
+};
+
+function MyTasksPage() {
+  const [tasks, setTasks] = useState<MyTasks>({ created: [], assigned: [] });
+  const [loading, setLoading] = useState(true);
+  const [searchValue, setSearchValue] = useState("");
+
+  const filteredTasks = useMemo(() => {
+    const query = searchValue.trim().toLowerCase();
+    if (!query) return tasks;
+    const matches = (task: TaskFromServer) =>
+      task.name.toLowerCase().includes(query) ||
+      (task.description ?? "").toLowerCase().includes(query);
+    return {
+      created: tasks.created.filter(matches),
+      assigned: tasks.assigned ? tasks.assigned.filter(matches) : null,
+    };
+  }, [tasks, searchValue]);
+
+  const fetchTasks = async () => {
+    setLoading(true);
+    try {
+      const res = await getMyTasksRequest();
+      if (res.success && res.data) {
+        setTasks(res.data);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchTasks();
+  }, []);
+
+  return (
+    <Page>
+      <WPQTPageHeader
+        description={__(
+          "Tasks you have created and tasks assigned to you.",
+          "quicktasker",
+        )}
+        rightSideContent={
+          <div className="wpqt-flex wpqt-items-center wpqt-gap-4">
+            <WPQTInput
+              value={searchValue}
+              onChange={(v) => setSearchValue(v)}
+              placeholder={__("Search tasks", "quicktasker")}
+              className="wpqt-w-52"
+              wrapperClassName="!wpqt-mb-0"
+              leftIcon={<MagnifyingGlassIcon className="wpqt-size-4" />}
+            />
+            <div className="wpqt-mx-5">
+              {loading ? (
+                <LoadingOval width="28" height="28" />
+              ) : (
+                <ArrowPathIcon
+                  className="wpqt-size-7 wpqt-cursor-pointer hover:wpqt-text-qtBlueHover"
+                  data-testid="refresh-icon"
+                  onClick={() => fetchTasks()}
+                />
+              )}
+            </div>
+          </div>
+        }
+      >
+        {__("My Tasks", "quicktasker")}
+      </WPQTPageHeader>
+
+      <MyTasksSection
+        title={__("Tasks I created", "quicktasker")}
+        tasks={filteredTasks.created}
+        emptyText={__("You haven't created any tasks yet.", "quicktasker")}
+        loading={loading}
+      />
+
+      {filteredTasks.assigned !== null && (
+        <MyTasksSection
+          title={__("Tasks assigned to me", "quicktasker")}
+          tasks={filteredTasks.assigned}
+          emptyText={__("No tasks assigned to you.", "quicktasker")}
+          loading={loading}
+        />
+      )}
+    </Page>
+  );
+}
+
+type SectionProps = {
+  title: string;
+  tasks: TaskFromServer[];
+  emptyText: string;
+  loading: boolean;
+};
+
+function MyTasksSection({ title, tasks, emptyText, loading }: SectionProps) {
+  const { convertToWPTimezone } = useTimezone();
+  return (
+    <div className="wpqt-mt-6">
+      <h2 className="wpqt-text-lg wpqt-font-semibold wpqt-mb-3">{title}</h2>
+      {loading ? (
+        <p className="wpqt-text-sm wpqt-text-gray-500">
+          {__("Loading…", "quicktasker")}
+        </p>
+      ) : tasks.length === 0 ? (
+        <p className="wpqt-text-sm wpqt-text-gray-500">{emptyText}</p>
+      ) : (
+        <div className="wpqt-card-grid">
+          {tasks.map((task) => (
+            <WPQTCard
+              key={task.id}
+              title={task.name}
+              description={task.description}
+            >
+              {task.pipeline_name && (
+                <div className="wpqt-text-xs wpqt-text-gray-500 wpqt-mt-2">
+                  {__("Board", "quicktasker")}: {task.pipeline_name}
+                </div>
+              )}
+              {task.stage_name && (
+                <div className="wpqt-text-xs wpqt-text-gray-500 wpqt-mt-1">
+                  {__("Stage", "quicktasker")}: {task.stage_name}
+                </div>
+              )}
+              <div className="wpqt-flex wpqt-items-center wpqt-gap-1 wpqt-text-xs wpqt-mt-1">
+                {task.is_done === "1" ? (
+                  <>
+                    <CheckCircleIcon className="wpqt-size-4 wpqt-text-green-600" />
+                    <span className="wpqt-text-green-600">
+                      {task.task_completed_at
+                        ? `${__("Done", "quicktasker")}: ${convertToWPTimezone(task.task_completed_at)}`
+                        : __("Done", "quicktasker")}
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <ClockIcon className="wpqt-size-4 wpqt-text-gray-500" />
+                    <span className="wpqt-text-gray-500">
+                      {__("In progress", "quicktasker")}
+                    </span>
+                  </>
+                )}
+              </div>
+              <div className="wpqt-text-xs wpqt-text-gray-500 wpqt-mt-1">
+                {__("Created", "quicktasker")}:{" "}
+                {convertToWPTimezone(task.created_at)}
+              </div>
+            </WPQTCard>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export { MyTasksPage };

--- a/src/pages/MyTasksPage/MyTasksPage.tsx
+++ b/src/pages/MyTasksPage/MyTasksPage.tsx
@@ -1,19 +1,12 @@
-import {
-  ArrowPathIcon,
-  CheckCircleIcon,
-  ClockIcon,
-  MagnifyingGlassIcon,
-} from "@heroicons/react/24/outline";
 import { useEffect, useMemo, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { getMyTasksRequest } from "../../api/api";
-import { WPQTCard } from "../../components/Card/Card";
 import { WPQTPageHeader } from "../../components/common/Header/Header";
-import { WPQTInput } from "../../components/common/Input/Input";
-import { LoadingOval } from "../../components/Loading/Loading";
-import { useTimezone } from "../../hooks/useTimezone";
+import { usePipelines } from "../../hooks/usePipelines";
 import { TaskFromServer } from "../../types/task";
 import { Page } from "../Page/Page";
+import { MyTasksHeaderControls } from "./components/MyTasksHeaderControls";
+import { MyTasksSection } from "./components/MyTasksSection";
 
 type MyTasks = {
   created: TaskFromServer[];
@@ -24,18 +17,29 @@ function MyTasksPage() {
   const [tasks, setTasks] = useState<MyTasks>({ created: [], assigned: [] });
   const [loading, setLoading] = useState(true);
   const [searchValue, setSearchValue] = useState("");
+  const [boardFilter, setBoardFilter] = useState("");
+  const { pipelines } = usePipelines();
+
+  const boardOptions = useMemo(
+    () => pipelines.map((p) => ({ value: p.id, label: p.name })),
+    [pipelines],
+  );
 
   const filteredTasks = useMemo(() => {
     const query = searchValue.trim().toLowerCase();
-    if (!query) return tasks;
-    const matches = (task: TaskFromServer) =>
-      task.name.toLowerCase().includes(query) ||
-      (task.description ?? "").toLowerCase().includes(query);
+    const matches = (task: TaskFromServer) => {
+      if (boardFilter && task.pipeline_id !== boardFilter) return false;
+      if (!query) return true;
+      return (
+        task.name.toLowerCase().includes(query) ||
+        (task.description ?? "").toLowerCase().includes(query)
+      );
+    };
     return {
       created: tasks.created.filter(matches),
       assigned: tasks.assigned ? tasks.assigned.filter(matches) : null,
     };
-  }, [tasks, searchValue]);
+  }, [tasks, searchValue, boardFilter]);
 
   const fetchTasks = async () => {
     setLoading(true);
@@ -61,27 +65,15 @@ function MyTasksPage() {
           "quicktasker",
         )}
         rightSideContent={
-          <div className="wpqt-flex wpqt-items-center wpqt-gap-4">
-            <WPQTInput
-              value={searchValue}
-              onChange={(v) => setSearchValue(v)}
-              placeholder={__("Search tasks", "quicktasker")}
-              className="wpqt-w-52"
-              wrapperClassName="!wpqt-mb-0"
-              leftIcon={<MagnifyingGlassIcon className="wpqt-size-4" />}
-            />
-            <div className="wpqt-mx-5">
-              {loading ? (
-                <LoadingOval width="28" height="28" />
-              ) : (
-                <ArrowPathIcon
-                  className="wpqt-size-7 wpqt-cursor-pointer hover:wpqt-text-qtBlueHover"
-                  data-testid="refresh-icon"
-                  onClick={() => fetchTasks()}
-                />
-              )}
-            </div>
-          </div>
+          <MyTasksHeaderControls
+            boardOptions={boardOptions}
+            boardFilter={boardFilter}
+            onBoardFilterChange={setBoardFilter}
+            searchValue={searchValue}
+            onSearchChange={setSearchValue}
+            loading={loading}
+            onRefresh={fetchTasks}
+          />
         }
       >
         {__("My Tasks", "quicktasker")}
@@ -90,7 +82,11 @@ function MyTasksPage() {
       <MyTasksSection
         title={__("Tasks I created", "quicktasker")}
         tasks={filteredTasks.created}
-        emptyText={__("You haven't created any tasks yet.", "quicktasker")}
+        emptyText={
+          boardFilter
+            ? __("You haven't created any tasks in this board.", "quicktasker")
+            : __("You haven't created any tasks yet.", "quicktasker")
+        }
         loading={loading}
       />
 
@@ -98,78 +94,15 @@ function MyTasksPage() {
         <MyTasksSection
           title={__("Tasks assigned to me", "quicktasker")}
           tasks={filteredTasks.assigned}
-          emptyText={__("No tasks assigned to you.", "quicktasker")}
+          emptyText={
+            boardFilter
+              ? __("No tasks assigned to you in this board.", "quicktasker")
+              : __("No tasks assigned to you.", "quicktasker")
+          }
           loading={loading}
         />
       )}
     </Page>
-  );
-}
-
-type SectionProps = {
-  title: string;
-  tasks: TaskFromServer[];
-  emptyText: string;
-  loading: boolean;
-};
-
-function MyTasksSection({ title, tasks, emptyText, loading }: SectionProps) {
-  const { convertToWPTimezone } = useTimezone();
-  return (
-    <div className="wpqt-mt-6">
-      <h2 className="wpqt-text-lg wpqt-font-semibold wpqt-mb-3">{title}</h2>
-      {loading ? (
-        <p className="wpqt-text-sm wpqt-text-gray-500">
-          {__("Loading…", "quicktasker")}
-        </p>
-      ) : tasks.length === 0 ? (
-        <p className="wpqt-text-sm wpqt-text-gray-500">{emptyText}</p>
-      ) : (
-        <div className="wpqt-card-grid">
-          {tasks.map((task) => (
-            <WPQTCard
-              key={task.id}
-              title={task.name}
-              description={task.description}
-            >
-              {task.pipeline_name && (
-                <div className="wpqt-text-xs wpqt-text-gray-500 wpqt-mt-2">
-                  {__("Board", "quicktasker")}: {task.pipeline_name}
-                </div>
-              )}
-              {task.stage_name && (
-                <div className="wpqt-text-xs wpqt-text-gray-500 wpqt-mt-1">
-                  {__("Stage", "quicktasker")}: {task.stage_name}
-                </div>
-              )}
-              <div className="wpqt-flex wpqt-items-center wpqt-gap-1 wpqt-text-xs wpqt-mt-1">
-                {task.is_done === "1" ? (
-                  <>
-                    <CheckCircleIcon className="wpqt-size-4 wpqt-text-green-600" />
-                    <span className="wpqt-text-green-600">
-                      {task.task_completed_at
-                        ? `${__("Done", "quicktasker")}: ${convertToWPTimezone(task.task_completed_at)}`
-                        : __("Done", "quicktasker")}
-                    </span>
-                  </>
-                ) : (
-                  <>
-                    <ClockIcon className="wpqt-size-4 wpqt-text-gray-500" />
-                    <span className="wpqt-text-gray-500">
-                      {__("In progress", "quicktasker")}
-                    </span>
-                  </>
-                )}
-              </div>
-              <div className="wpqt-text-xs wpqt-text-gray-500 wpqt-mt-1">
-                {__("Created", "quicktasker")}:{" "}
-                {convertToWPTimezone(task.created_at)}
-              </div>
-            </WPQTCard>
-          ))}
-        </div>
-      )}
-    </div>
   );
 }
 

--- a/src/pages/MyTasksPage/components/MyTasksHeaderControls.tsx
+++ b/src/pages/MyTasksPage/components/MyTasksHeaderControls.tsx
@@ -1,0 +1,63 @@
+import {
+  ArrowPathIcon,
+  MagnifyingGlassIcon,
+} from "@heroicons/react/24/outline";
+import { __ } from "@wordpress/i18n";
+import { WPQTInput } from "../../../components/common/Input/Input";
+import { WPQTSelect } from "../../../components/common/Select/WPQTSelect";
+import { LoadingOval } from "../../../components/Loading/Loading";
+
+type BoardOption = { value: string; label: string };
+
+type Props = {
+  boardOptions: BoardOption[];
+  boardFilter: string;
+  onBoardFilterChange: (value: string) => void;
+  searchValue: string;
+  onSearchChange: (value: string) => void;
+  loading: boolean;
+  onRefresh: () => void;
+};
+
+function MyTasksHeaderControls({
+  boardOptions,
+  boardFilter,
+  onBoardFilterChange,
+  searchValue,
+  onSearchChange,
+  loading,
+  onRefresh,
+}: Props) {
+  return (
+    <div className="wpqt-flex wpqt-items-center wpqt-gap-4">
+      <WPQTSelect
+        options={boardOptions}
+        selectedOptionValue={boardFilter}
+        onSelectionChange={onBoardFilterChange}
+        allSelectorLabel={__("All boards", "quicktasker")}
+        className="!wpqt-h-[30px] !wpqt-min-h-[30px] !wpqt-py-0 !wpqt-pl-2 !wpqt-pr-6 !wpqt-text-sm/6 !wpqt-border-[#8c8f94] !wpqt-shadow-none"
+      />
+      <WPQTInput
+        value={searchValue}
+        onChange={onSearchChange}
+        placeholder={__("Search tasks", "quicktasker")}
+        className="wpqt-w-52"
+        wrapperClassName="!wpqt-mb-0"
+        leftIcon={<MagnifyingGlassIcon className="wpqt-size-4" />}
+      />
+      <div className="wpqt-mx-5">
+        {loading ? (
+          <LoadingOval width="28" height="28" />
+        ) : (
+          <ArrowPathIcon
+            className="wpqt-size-7 wpqt-cursor-pointer hover:wpqt-text-qtBlueHover"
+            data-testid="refresh-icon"
+            onClick={onRefresh}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+export { MyTasksHeaderControls };

--- a/src/pages/MyTasksPage/components/MyTasksSection.tsx
+++ b/src/pages/MyTasksPage/components/MyTasksSection.tsx
@@ -1,0 +1,80 @@
+import { CheckCircleIcon, ClockIcon } from "@heroicons/react/24/outline";
+import { __ } from "@wordpress/i18n";
+import { WPQTCard } from "../../../components/Card/Card";
+import { useTimezone } from "../../../hooks/useTimezone";
+import { TaskFromServer } from "../../../types/task";
+
+type SectionProps = {
+  title: string;
+  tasks: TaskFromServer[];
+  emptyText: string;
+  loading: boolean;
+};
+
+function MyTasksSection({ title, tasks, emptyText, loading }: SectionProps) {
+  const { convertToWPTimezone } = useTimezone();
+  return (
+    <div className="wpqt-mt-6">
+      <h2 className="wpqt-text-lg wpqt-font-semibold wpqt-mb-3">{title}</h2>
+      {loading ? (
+        <p className="wpqt-text-sm wpqt-text-gray-500">
+          {__("Loading…", "quicktasker")}
+        </p>
+      ) : tasks.length === 0 ? (
+        <p className="wpqt-text-sm wpqt-text-gray-500">{emptyText}</p>
+      ) : (
+        <div className="wpqt-card-grid">
+          {tasks.map((task) => (
+            <WPQTCard
+              key={task.id}
+              title={task.name}
+              description={task.description}
+            >
+              {task.pipeline_name && (
+                <div className="wpqt-text-xs wpqt-text-gray-500 wpqt-mt-2">
+                  {__("Board", "quicktasker")}:{" "}
+                  <a
+                    href={`admin.php?page=wp-quicktasker#/board/${task.pipeline_id}`}
+                    className="wpqt-text-qtBlue hover:wpqt-text-qtBlueHover"
+                  >
+                    {task.pipeline_name}
+                  </a>
+                </div>
+              )}
+              {task.stage_name && (
+                <div className="wpqt-text-xs wpqt-text-gray-500 wpqt-mt-1">
+                  {__("Stage", "quicktasker")}: {task.stage_name}
+                </div>
+              )}
+              <div className="wpqt-flex wpqt-items-center wpqt-gap-1 wpqt-text-xs wpqt-mt-1">
+                {task.is_done === "1" ? (
+                  <>
+                    <CheckCircleIcon className="wpqt-size-4 wpqt-text-green-600" />
+                    <span className="wpqt-text-green-600">
+                      {task.task_completed_at
+                        ? `${__("Done", "quicktasker")}: ${convertToWPTimezone(task.task_completed_at)}`
+                        : __("Done", "quicktasker")}
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <ClockIcon className="wpqt-size-4 wpqt-text-gray-500" />
+                    <span className="wpqt-text-gray-500">
+                      {__("In progress", "quicktasker")}
+                    </span>
+                  </>
+                )}
+              </div>
+              <div className="wpqt-text-xs wpqt-text-gray-500 wpqt-mt-1">
+                {__("Created", "quicktasker")}:{" "}
+                {convertToWPTimezone(task.created_at)}
+              </div>
+            </WPQTCard>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export { MyTasksSection };

--- a/src/pages/MyTasksPage/components/MyTasksSection.tsx
+++ b/src/pages/MyTasksPage/components/MyTasksSection.tsx
@@ -1,8 +1,14 @@
-import { CheckCircleIcon, ClockIcon } from "@heroicons/react/24/outline";
+import { CheckBadgeIcon, UserCircleIcon } from "@heroicons/react/24/outline";
 import { __ } from "@wordpress/i18n";
 import { WPQTCard } from "../../../components/Card/Card";
+import { WPQTTag } from "../../../components/common/Tag/Tag";
+import { DueDateInfo } from "../../../components/Icon/DueDateInfo/DueDateInfo";
+import {
+  TASK_FOCUS_BORDER_STYLE,
+  TASK_FOCUS_BORDER_WIDTH,
+} from "../../../constants";
 import { useTimezone } from "../../../hooks/useTimezone";
-import { TaskFromServer } from "../../../types/task";
+import { Task, TaskFromServer } from "../../../types/task";
 
 type SectionProps = {
   title: string;
@@ -29,6 +35,15 @@ function MyTasksSection({ title, tasks, emptyText, loading }: SectionProps) {
               key={task.id}
               title={task.name}
               description={task.description}
+              style={
+                task.task_focus_color
+                  ? {
+                      borderTopColor: task.task_focus_color,
+                      borderTopWidth: TASK_FOCUS_BORDER_WIDTH,
+                      borderTopStyle: TASK_FOCUS_BORDER_STYLE,
+                    }
+                  : undefined
+              }
             >
               {task.pipeline_name && (
                 <div className="wpqt-text-xs wpqt-text-gray-500 wpqt-mt-2">
@@ -46,10 +61,47 @@ function MyTasksSection({ title, tasks, emptyText, loading }: SectionProps) {
                   {__("Stage", "quicktasker")}: {task.stage_name}
                 </div>
               )}
-              <div className="wpqt-flex wpqt-items-center wpqt-gap-1 wpqt-text-xs wpqt-mt-1">
+              <div className="wpqt-text-xs wpqt-text-gray-500 wpqt-mt-1">
+                {__("Created", "quicktasker")}:{" "}
+                {convertToWPTimezone(task.created_at)}
+              </div>
+              {(() => {
+                const users = [
+                  ...(task.assigned_users || []),
+                  ...(task.assigned_wp_users || []),
+                ];
+                if (users.length === 0) return null;
+                return (
+                  <div className="wpqt-flex wpqt-items-start wpqt-gap-1 wpqt-text-xs wpqt-text-gray-500 wpqt-mt-2">
+                    <UserCircleIcon className="wpqt-size-5 wpqt-text-blue-400 wpqt-shrink-0" />
+                    <div className="wpqt-flex wpqt-flex-wrap wpqt-gap-x-1">
+                      {users.map((user, index) => (
+                        <span key={index}>
+                          {user.name}
+                          {index < users.length - 1 && ","}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })()}
+              {Array.isArray(task.assigned_labels) &&
+                task.assigned_labels.length > 0 && (
+                  <div className="wpqt-flex wpqt-flex-wrap wpqt-gap-1 wpqt-mt-2">
+                    {task.assigned_labels.map((label) => (
+                      <WPQTTag
+                        key={label.id}
+                        inlineStyle={{ backgroundColor: label.color }}
+                      >
+                        {label.name}
+                      </WPQTTag>
+                    ))}
+                  </div>
+                )}
+              <div className="wpqt-flex wpqt-items-center wpqt-gap-1 wpqt-text-xs wpqt-mt-3">
                 {task.is_done === "1" ? (
                   <>
-                    <CheckCircleIcon className="wpqt-size-4 wpqt-text-green-600" />
+                    <CheckBadgeIcon className="wpqt-size-5 wpqt-icon-green" />
                     <span className="wpqt-text-green-600">
                       {task.task_completed_at
                         ? `${__("Done", "quicktasker")}: ${convertToWPTimezone(task.task_completed_at)}`
@@ -58,17 +110,18 @@ function MyTasksSection({ title, tasks, emptyText, loading }: SectionProps) {
                   </>
                 ) : (
                   <>
-                    <ClockIcon className="wpqt-size-4 wpqt-text-gray-500" />
+                    <CheckBadgeIcon className="wpqt-size-5 wpqt-text-gray-500" />
                     <span className="wpqt-text-gray-500">
                       {__("In progress", "quicktasker")}
                     </span>
                   </>
                 )}
               </div>
-              <div className="wpqt-text-xs wpqt-text-gray-500 wpqt-mt-1">
-                {__("Created", "quicktasker")}:{" "}
-                {convertToWPTimezone(task.created_at)}
-              </div>
+              {task.due_date && (
+                <div className="wpqt-mt-1">
+                  <DueDateInfo task={task as unknown as Task} />
+                </div>
+              )}
             </WPQTCard>
           ))}
         </div>

--- a/src/pages/UserManagement/components/WPUserItem/WPUserItem.test.tsx
+++ b/src/pages/UserManagement/components/WPUserItem/WPUserItem.test.tsx
@@ -79,8 +79,9 @@ beforeEach(() => {
 // 1: quicktasker_admin_role_manage_users
 // 2: quicktasker_admin_role_manage_settings
 // 3: quicktasker_admin_role_manage_archive
-// 4: quicktasker_admin_role_allow_delete
-// 5: quicktasker_access_user_page_app
+// 4: quicktasker_access_user_page_app
+// 5: quicktasker_admin_role_allow_delete
+// 6: quicktasker_view_my_tasks
 
 describe("WPUserItem", () => {
   describe("capability initialisation from allcaps", () => {
@@ -102,7 +103,7 @@ describe("WPUserItem", () => {
       const checkboxes = screen.getAllByRole("checkbox");
       expect(checkboxes[0]).toBeChecked();
       expect(checkboxes[1]).not.toBeChecked();
-      expect(checkboxes[5]).toBeChecked();
+      expect(checkboxes[4]).toBeChecked();
     });
   });
 

--- a/src/pages/UserManagement/components/WPUserItem/WPUserItem.tsx
+++ b/src/pages/UserManagement/components/WPUserItem/WPUserItem.tsx
@@ -25,6 +25,7 @@ function WPUserItem({ user }: Props) {
         "quicktasker_admin_role_manage_archive" in user.allcaps,
       quicktasker_access_user_page_app:
         "quicktasker_access_user_page_app" in user.allcaps,
+      quicktasker_view_my_tasks: "quicktasker_view_my_tasks" in user.allcaps,
     });
   const [updating, setUpdating] = useState(false);
   const { updateWPUserCapabilities } = useCapabilityActions();
@@ -69,67 +70,94 @@ function WPUserItem({ user }: Props) {
             onToggleChange(checked, "quicktasker_admin_role");
           }}
         />
+
+        <div className="wpqt-mt-3 wpqt-pl-4 wpqt-border-l-2 wpqt-border-gray-200">
+          <div className="wpqt-mb-2">
+            <div className="wpqt-mb-2">
+              {__("Access to user management", "quicktasker")}
+            </div>
+            <Toggle
+              checked={capabilitySettings.quicktasker_admin_role_manage_users}
+              disabled={!capabilitySettings.quicktasker_admin_role}
+              handleChange={(checked: boolean) => {
+                onToggleChange(checked, "quicktasker_admin_role_manage_users");
+              }}
+            />
+          </div>
+
+          <div className="wpqt-mb-2">
+            <div className="wpqt-mb-2">
+              {__(
+                "Access to manage settings (boards, stages, automations, webhooks, api tokens)",
+                "quicktasker",
+              )}
+            </div>
+            <Toggle
+              checked={
+                capabilitySettings.quicktasker_admin_role_manage_settings
+              }
+              disabled={!capabilitySettings.quicktasker_admin_role}
+              handleChange={(checked: boolean) => {
+                onToggleChange(
+                  checked,
+                  "quicktasker_admin_role_manage_settings",
+                );
+              }}
+            />
+          </div>
+
+          <div className="wpqt-mb-2">
+            <div className="wpqt-mb-2">
+              {__("Access to archive page", "quicktasker")}
+            </div>
+            <Toggle
+              checked={capabilitySettings.quicktasker_admin_role_manage_archive}
+              disabled={!capabilitySettings.quicktasker_admin_role}
+              handleChange={(checked: boolean) => {
+                onToggleChange(
+                  checked,
+                  "quicktasker_admin_role_manage_archive",
+                );
+              }}
+            />
+          </div>
+
+          <div className="wpqt-mb-2">
+            <div className="wpqt-mb-2">
+              {__("Allow access to Tasks App", "quicktasker")}
+            </div>
+            <Toggle
+              checked={capabilitySettings.quicktasker_access_user_page_app}
+              disabled={!capabilitySettings.quicktasker_admin_role}
+              handleChange={(checked: boolean) => {
+                onToggleChange(checked, "quicktasker_access_user_page_app");
+              }}
+            />
+          </div>
+
+          <div className="wpqt-mb-2">
+            <div className="wpqt-mb-2">
+              {__("Allow to delete resources", "quicktasker")}
+            </div>
+            <Toggle
+              checked={capabilitySettings.quicktasker_admin_role_allow_delete}
+              disabled={!capabilitySettings.quicktasker_admin_role}
+              handleChange={(checked: boolean) => {
+                onToggleChange(checked, "quicktasker_admin_role_allow_delete");
+              }}
+            />
+          </div>
+        </div>
       </div>
 
       <div className="wpqt-mb-2">
         <div className="wpqt-mb-2">
-          {__("Access to user management", "quicktasker")}
+          {__("Access to My Tasks page", "quicktasker")}
         </div>
         <Toggle
-          checked={capabilitySettings.quicktasker_admin_role_manage_users}
+          checked={capabilitySettings.quicktasker_view_my_tasks}
           handleChange={(checked: boolean) => {
-            onToggleChange(checked, "quicktasker_admin_role_manage_users");
-          }}
-        />
-      </div>
-
-      <div className="wpqt-mb-2">
-        <div className="wpqt-mb-2">
-          {__(
-            "Access to manage settings (boards, stages, automations, webhooks, api tokens)",
-            "quicktasker",
-          )}
-        </div>
-        <Toggle
-          checked={capabilitySettings.quicktasker_admin_role_manage_settings}
-          handleChange={(checked: boolean) => {
-            onToggleChange(checked, "quicktasker_admin_role_manage_settings");
-          }}
-        />
-      </div>
-
-      <div className="wpqt-mb-2">
-        <div className="wpqt-mb-2">
-          {__("Access to archive page", "quicktasker")}
-        </div>
-        <Toggle
-          checked={capabilitySettings.quicktasker_admin_role_manage_archive}
-          handleChange={(checked: boolean) => {
-            onToggleChange(checked, "quicktasker_admin_role_manage_archive");
-          }}
-        />
-      </div>
-
-      <div className="wpqt-mb-2">
-        <div className="wpqt-mb-2">
-          {__("Allow to delete resources", "quicktasker")}
-        </div>
-        <Toggle
-          checked={capabilitySettings.quicktasker_admin_role_allow_delete}
-          handleChange={(checked: boolean) => {
-            onToggleChange(checked, "quicktasker_admin_role_allow_delete");
-          }}
-        />
-      </div>
-
-      <div className="wpqt-mb-2">
-        <div className="wpqt-mb-2">
-          {__("Allow access to user tasks app", "quicktasker")}
-        </div>
-        <Toggle
-          checked={capabilitySettings.quicktasker_access_user_page_app}
-          handleChange={(checked: boolean) => {
-            onToggleChange(checked, "quicktasker_access_user_page_app");
+            onToggleChange(checked, "quicktasker_view_my_tasks");
           }}
         />
       </div>

--- a/src/types/capabilities.ts
+++ b/src/types/capabilities.ts
@@ -5,6 +5,7 @@ type WPUserCapabilities = {
   quicktasker_admin_role_manage_settings: boolean;
   quicktasker_admin_role_manage_archive: boolean;
   quicktasker_access_user_page_app: boolean;
+  quicktasker_view_my_tasks: boolean;
 };
 
 export type { WPUserCapabilities };

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -6,6 +6,7 @@ type BaseTask = {
   pipeline_id: string;
   pipeline_name: string | null;
   stage_id: string;
+  stage_name?: string | null;
   name: string;
   description: string;
   task_hash: string;
@@ -13,6 +14,7 @@ type BaseTask = {
   assigned_labels: Label[];
   due_date: string | null;
   task_focus_color: string | null;
+  task_completed_at?: string | null;
 };
 
 type Task = BaseTask & {

--- a/tests/e2e/my-tasks.spec.ts
+++ b/tests/e2e/my-tasks.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import { navigateToBoardsPage } from './utils/navigation';
+import { createBoard, createStage, createTask, generateUniqueName, generateUniqueDescription } from './utils/board-helpers';
+import { assignWordPressUserToTask, closeUserAssignmentDropdown } from './utils/user-helpers';
+import { ADMIN_USERNAME } from './constants';
+import { TIMEOUTS } from './utils/timeouts';
+
+test.describe('My Tasks page', () => {
+  test('shows tasks created by and assigned to the current user', async ({ page }) => {
+    const stageName = generateUniqueName('MT-Stage');
+    const createdTaskName = generateUniqueName('MT-Created');
+    const assignedTaskName = generateUniqueName('MT-Assigned');
+
+    await navigateToBoardsPage(page);
+    await createBoard(page, generateUniqueName('MT-Board'), generateUniqueDescription('Board for My Tasks e2e'));
+    await createStage(page, stageName);
+
+    await createTask(page, stageName, createdTaskName);
+
+    await createTask(page, stageName, assignedTaskName);
+    await assignWordPressUserToTask(page, assignedTaskName, ADMIN_USERNAME, false);
+    await closeUserAssignmentDropdown(page, assignedTaskName);
+
+    await page.goto('/wp-admin/admin.php?page=wp-quicktasker-my-tasks');
+    await expect(page.getByRole('heading', { name: 'My Tasks' })).toBeVisible({ timeout: TIMEOUTS.NAVIGATION });
+
+    const createdSection = page
+      .locator('div.wpqt-mt-6')
+      .filter({ has: page.getByRole('heading', { name: 'Tasks I created' }) });
+    const assignedSection = page
+      .locator('div.wpqt-mt-6')
+      .filter({ has: page.getByRole('heading', { name: 'Tasks assigned to me' }) });
+
+    await expect(createdSection.getByText(createdTaskName)).toBeVisible();
+    await expect(createdSection.getByText(assignedTaskName)).toBeVisible();
+    await expect(assignedSection.getByText(assignedTaskName)).toBeVisible();
+  });
+});

--- a/tests/e2e/user-management-wp-user-permissions.spec.ts
+++ b/tests/e2e/user-management-wp-user-permissions.spec.ts
@@ -301,6 +301,91 @@ test.describe('WP User Capabilities – Manage Settings', () => {
   });
 });
 
+test.describe('WP User Capabilities – View My Tasks', () => {
+  test('My Tasks submenu is not visible without the capability', async ({ browser, request }) => {
+    const userLogin = uniqueLogin('wpnomytasks');
+    const userId = await createWPUser(request, userLogin, `${userLogin}@example.com`, 'editor');
+    await grantWPUserCaps(request, userId, ['quicktasker_admin_role']);
+    const { context, page } = await loginAsWPUser(browser, userLogin);
+    await page.goto('/wp-admin/admin.php?page=wp-quicktasker');
+    await expect(page.getByTestId('pipeline-selection-dropdown')).toBeVisible({
+      timeout: TIMEOUTS.NAVIGATION,
+    });
+    await expect(
+      page.locator('#adminmenu').getByRole('link', { name: 'My Tasks' }),
+    ).not.toBeVisible();
+    await context.close();
+  });
+
+  test('accessing My Tasks page directly shows insufficient permissions error', async ({ browser, request }) => {
+    const userLogin = uniqueLogin('wpnomytasks');
+    await createWPUser(request, userLogin, `${userLogin}@example.com`, 'editor');
+    const { context, page } = await loginAsWPUser(browser, userLogin);
+    await page.goto('/wp-admin/admin.php?page=wp-quicktasker-my-tasks');
+    await expect(page.getByText('Sorry, you are not allowed to access this page.')).toBeVisible({
+      timeout: TIMEOUTS.NAVIGATION,
+    });
+    await context.close();
+  });
+
+  test('user with only view-my-tasks cap sees QuickTasker menu and My Tasks submenu', async ({ browser, request }) => {
+    const userLogin = uniqueLogin('wpmytasks');
+    const userId = await createWPUser(request, userLogin, `${userLogin}@example.com`, 'editor');
+    await grantWPUserCaps(request, userId, ['quicktasker_view_my_tasks']);
+    const { context, page } = await loginAsWPUser(browser, userLogin);
+    await page.goto('/wp-admin/');
+    await expect(
+      page.locator('#adminmenu').getByRole('link', { name: 'QuickTasker', exact: true }),
+    ).toBeVisible({ timeout: TIMEOUTS.NAVIGATION });
+    await expect(
+      page.locator('#adminmenu').getByRole('link', { name: 'My Tasks' }),
+    ).toBeVisible();
+    await context.close();
+  });
+
+  test('user with only view-my-tasks cap can load the My Tasks page but no Boards', async ({ browser, request }) => {
+    const userLogin = uniqueLogin('wpmytasks');
+    const userId = await createWPUser(request, userLogin, `${userLogin}@example.com`, 'editor');
+    await grantWPUserCaps(request, userId, ['quicktasker_view_my_tasks']);
+    const { context, page } = await loginAsWPUser(browser, userLogin);
+    await page.goto('/wp-admin/admin.php?page=wp-quicktasker-my-tasks');
+    await expect(page.getByRole('heading', { name: 'My Tasks' })).toBeVisible({
+      timeout: TIMEOUTS.NAVIGATION,
+    });
+    await expect(page.getByText('Tasks I created')).toBeVisible();
+    await expect(
+      page.locator('#adminmenu').getByRole('link', { name: 'Boards' }),
+    ).not.toBeVisible();
+    await context.close();
+  });
+
+  test('non-admin user does not see the "Tasks assigned to me" section', async ({ browser, request }) => {
+    const userLogin = uniqueLogin('wpmytasks');
+    const userId = await createWPUser(request, userLogin, `${userLogin}@example.com`, 'editor');
+    await grantWPUserCaps(request, userId, ['quicktasker_view_my_tasks']);
+    const { context, page } = await loginAsWPUser(browser, userLogin);
+    await page.goto('/wp-admin/admin.php?page=wp-quicktasker-my-tasks');
+    await expect(page.getByText('Tasks I created')).toBeVisible({
+      timeout: TIMEOUTS.NAVIGATION,
+    });
+    await expect(page.getByText('Tasks assigned to me')).not.toBeVisible();
+    await context.close();
+  });
+
+  test('admin user sees the "Tasks assigned to me" section', async ({ browser, request }) => {
+    const userLogin = uniqueLogin('wpmytasksadmin');
+    const userId = await createWPUser(request, userLogin, `${userLogin}@example.com`, 'editor');
+    await grantWPUserCaps(request, userId, ['quicktasker_admin_role', 'quicktasker_view_my_tasks']);
+    const { context, page } = await loginAsWPUser(browser, userLogin);
+    await page.goto('/wp-admin/admin.php?page=wp-quicktasker-my-tasks');
+    await expect(page.getByText('Tasks I created')).toBeVisible({
+      timeout: TIMEOUTS.NAVIGATION,
+    });
+    await expect(page.getByText('Tasks assigned to me')).toBeVisible();
+    await context.close();
+  });
+});
+
 test.describe('WP User Capabilities – Allow Delete', () => {
   test('Delete stage option is visible in stage controls dropdown', async ({ browser, request }) => {
     const userLogin = uniqueLogin('wpdelete');

--- a/tests/e2e/user-management-wp-users.spec.ts
+++ b/tests/e2e/user-management-wp-users.spec.ts
@@ -45,8 +45,8 @@ test.describe('WordPress Users Tab – User Card', () => {
     const card = page.getByTestId('wpqt-card').filter({ hasText: userLogin });
     await expect(card).toBeVisible({ timeout: TIMEOUTS.NAVIGATION });
     const toggles = card.getByRole('switch');
-    await expect(toggles).toHaveCount(6);
-    for (let i = 0; i < 6; i++) {
+    await expect(toggles).toHaveCount(7);
+    for (let i = 0; i < 7; i++) {
       await expect(toggles.nth(i)).toHaveAttribute('aria-checked', 'false');
     }
   });

--- a/tests/e2e/utils/user-helpers.ts
+++ b/tests/e2e/utils/user-helpers.ts
@@ -14,6 +14,7 @@ const ALL_CAPS = [
   'quicktasker_admin_role_manage_settings',
   'quicktasker_admin_role_manage_archive',
   'quicktasker_access_user_page_app',
+  'quicktasker_view_my_tasks',
 ] as const;
 
 async function getAdminNonce(request: APIRequestContext): Promise<string> {

--- a/tests/unit/be/repositories/TaskRepositoryTest.php
+++ b/tests/unit/be/repositories/TaskRepositoryTest.php
@@ -25,6 +25,9 @@ if (!defined('TABLE_WP_QUICKTASKER_PIPELINE_STAGES')) {
 if (!defined('WP_QT_QUICKTASKER_USER_TYPE')) {
     define('WP_QT_QUICKTASKER_USER_TYPE', 'quicktasker');
 }
+if (!defined('WP_QT_WORDPRESS_USER_TYPE')) {
+    define('WP_QT_WORDPRESS_USER_TYPE', 'wp-user');
+}
 if (!defined('WP_QUICKTASKER_WP_USER_OBJECT_FILTER_ADMIN_FE')) {
     define('WP_QUICKTASKER_WP_USER_OBJECT_FILTER_ADMIN_FE', 'admin_fe');
 }
@@ -389,6 +392,97 @@ class TaskRepositoryTest extends TestCase
         $result = $this->repository->getTasksAssignedToUser($userId);
 
         $this->assertSame($expectedTasks, $result);
+    }
+
+    public function test_getTasksAssignedToUser_query_selects_stage_name()
+    {
+        $this->wpdbMock->expects($this->once())
+            ->method('prepare')
+            ->with(
+                $this->stringContains('e.name as stage_name'),
+                $this->anything()
+            )
+            ->willReturn('PREPARED_SQL');
+
+        $this->wpdbMock->expects($this->once())
+            ->method('get_results')
+            ->willReturn([]);
+
+        $this->repository->getTasksAssignedToUser(5);
+    }
+
+    public function test_getTasksCreatedByUser_returns_tasks_for_wp_user()
+    {
+        $userId = 7;
+        $preparedSql = 'PREPARED_SQL';
+        $expectedTasks = [
+            (object)[
+                'id' => 1,
+                'name' => 'Created Task',
+                'pipeline_name' => 'Board A',
+                'stage_name' => 'In Progress',
+                'created_by_id' => $userId,
+                'created_by_type' => WP_QT_WORDPRESS_USER_TYPE,
+            ],
+        ];
+
+        $this->wpdbMock->expects($this->once())
+            ->method('prepare')
+            ->with(
+                $this->logicalAnd(
+                    $this->stringContains('a.created_by_id = %d'),
+                    $this->stringContains('a.created_by_type = %s'),
+                    $this->stringContains('a.is_archived = 0'),
+                    $this->stringContains('e.name as stage_name')
+                ),
+                $userId,
+                WP_QT_WORDPRESS_USER_TYPE
+            )
+            ->willReturn($preparedSql);
+
+        $this->wpdbMock->expects($this->once())
+            ->method('get_results')
+            ->with($preparedSql)
+            ->willReturn($expectedTasks);
+
+        $result = $this->repository->getTasksCreatedByUser($userId);
+
+        $this->assertSame($expectedTasks, $result);
+    }
+
+    public function test_getTasksCreatedByUser_passes_quicktasker_user_type()
+    {
+        $userId = 12;
+
+        $this->wpdbMock->expects($this->once())
+            ->method('prepare')
+            ->with(
+                $this->anything(),
+                $userId,
+                WP_QT_QUICKTASKER_USER_TYPE
+            )
+            ->willReturn('PREPARED_SQL');
+
+        $this->wpdbMock->expects($this->once())
+            ->method('get_results')
+            ->willReturn([]);
+
+        $this->repository->getTasksCreatedByUser($userId, WP_QT_QUICKTASKER_USER_TYPE);
+    }
+
+    public function test_getTasksCreatedByUser_returns_empty_when_no_matches()
+    {
+        $this->wpdbMock->expects($this->once())
+            ->method('prepare')
+            ->willReturn('PREPARED_SQL');
+
+        $this->wpdbMock->expects($this->once())
+            ->method('get_results')
+            ->willReturn([]);
+
+        $result = $this->repository->getTasksCreatedByUser(99);
+
+        $this->assertSame([], $result);
     }
 
     public function test_getTasksAssignableToUser_returns_free_for_all_tasks()


### PR DESCRIPTION
Adds a new My Tasks admin page listing tasks the current user created and tasks assigned to them, with board filter, search and refresh. Cards mirror the board view: task focus color border, assigned labels, assigned QT/WP users, due date, and done/in-progress status.

Introduces a new quicktasker_view_my_tasks capability and exposes it as a separate toggle in the WP user management card. The page uses its own menu slug (wp-quicktasker-my-tasks) so non-admins can access it without WP_QUICKTASKER_ADMIN_ROLE. Submenu highlight logic was extended to recognize the standalone slug.

Tasks now persist created_by_id / created_by_type (polymorphic: wp-user | quicktasker) so "tasks I created" can be queried directly. Public token submissions also capture the WP creator when available. Old rows remain NULL — no backfill.

Reorganized the WP user capability toggles: admin sub-capabilities (user management, settings, archive, Tasks App, delete) are nested under "Access to plugin admin area" and disabled when the parent is off. "Access to My Tasks page" stays separate.

Adds a minimal e2e test covering the page surfacing both creator-attribution and assignment data, plus a Help docs section for the new page.