### PR TITLE
Add per-board toggles to disable automation, webhook and API token logs

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -3,7 +3,7 @@
 # List of files and directories to remove
 FILES_TO_REMOVE=(
     "tsconfig.json"
-    ".eslintrc.json"
+    ".eslint.config.js"
     ".prettierrc"
     ".vscode"
     ".github"

--- a/php/api/admin-api.php
+++ b/php/api/admin-api.php
@@ -3180,6 +3180,15 @@ if (!function_exists('wpqt_register_api_routes')) {
                         if (isset($data['require_logged_in_user'])) {
                             $settings['require_logged_in_user'] = $data['require_logged_in_user'] ? 1 : 0;
                         }
+                        if (isset($data['enable_automation_logs'])) {
+                            $settings['enable_automation_logs'] = $data['enable_automation_logs'] ? 1 : 0;
+                        }
+                        if (isset($data['enable_webhook_logs'])) {
+                            $settings['enable_webhook_logs'] = $data['enable_webhook_logs'] ? 1 : 0;
+                        }
+                        if (isset($data['enable_api_token_logs'])) {
+                            $settings['enable_api_token_logs'] = $data['enable_api_token_logs'] ? 1 : 0;
+                        }
 
                         if (0 === count($settings)) {
                             return new WP_REST_Response((new ApiResponse(false, [esc_html_e('No valid settings provided', 'quicktasker')]))->toArray(), 200);
@@ -3227,6 +3236,21 @@ if (!function_exists('wpqt_register_api_routes')) {
                         'sanitize_callback' => ['WPQT\RequestValidation', 'sanitizeAbsint'],
                     ],
                     'require_logged_in_user' => [
+                        'required'          => false,
+                        'validate_callback' => ['WPQT\RequestValidation', 'validateBooleanParam'],
+                        'sanitize_callback' => ['WPQT\RequestValidation', 'sanitizeBooleanParam'],
+                    ],
+                    'enable_automation_logs' => [
+                        'required'          => false,
+                        'validate_callback' => ['WPQT\RequestValidation', 'validateBooleanParam'],
+                        'sanitize_callback' => ['WPQT\RequestValidation', 'sanitizeBooleanParam'],
+                    ],
+                    'enable_webhook_logs' => [
+                        'required'          => false,
+                        'validate_callback' => ['WPQT\RequestValidation', 'validateBooleanParam'],
+                        'sanitize_callback' => ['WPQT\RequestValidation', 'sanitizeBooleanParam'],
+                    ],
+                    'enable_api_token_logs' => [
                         'required'          => false,
                         'validate_callback' => ['WPQT\RequestValidation', 'validateBooleanParam'],
                         'sanitize_callback' => ['WPQT\RequestValidation', 'sanitizeBooleanParam'],

--- a/php/api/token-api.php
+++ b/php/api/token-api.php
@@ -40,6 +40,18 @@ function wpqtIsEntityUnauthorizedForPipeline($entity, $pipelineId)
     return !$entity || $entity->pipeline_id !== $pipelineId;
 }
 
+/**
+ * Writes an API-token log entry only if the board has API token logs enabled.
+ */
+function wpqtTokenLog($pipelineId, $text, array $args)
+{
+    $logService = ServiceLocator::get('LogService');
+    if (!$logService->shouldLog($pipelineId, \WPQT\Log\LogService::SOURCE_API_TOKEN)) {
+        return;
+    }
+    $logService->log($text, $args);
+}
+
 add_action('rest_api_init', 'wpqt_register_token_api_routes');
 function wpqt_register_token_api_routes()
 {
@@ -63,7 +75,8 @@ function wpqt_register_token_api_routes()
                     ]);
                 }
 
-                ServiceLocator::get('LogService')->log(
+                wpqtTokenLog(
+                    $cachedDbToken->pipeline_id,
                     "Board {$pipeline->name} fetched by {$apiTokenRepository->getApiTokenName($cachedDbToken)}",
                     [
                         'type'          => WP_QT_LOG_TYPE_PIPELINE,
@@ -100,7 +113,8 @@ function wpqt_register_token_api_routes()
                 $paramsToUpdate = wpqtBuildParamsFromRequest($request, ['name', 'description']);
                 $updatedPipeline = ServiceLocator::get('PipelineService')->editPipeline($cachedDbToken->pipeline_id, $paramsToUpdate);
 
-                ServiceLocator::get('LogService')->log(
+                wpqtTokenLog(
+                    $cachedDbToken->pipeline_id,
                     "Board {$updatedPipeline->name} edited by {$apiTokenRepository->getApiTokenName($cachedDbToken)}",
                     [
                         'type'          => WP_QT_LOG_TYPE_PIPELINE,
@@ -158,7 +172,8 @@ function wpqt_register_token_api_routes()
                     throw new \Exception('No stages found for the board associated with the provided token.');
                 }
 
-                ServiceLocator::get('LogService')->log(
+                wpqtTokenLog(
+                    $cachedDbToken->pipeline_id,
                     "Board stages fetched by {$apiTokenRepository->getApiTokenName($cachedDbToken)}",
                     [
                         'type'          => WP_QT_LOG_TYPE_PIPELINE,
@@ -195,7 +210,8 @@ function wpqt_register_token_api_routes()
                 $stageData = wpqtBuildParamsFromRequest($request, ['name', 'description']);
                 $stage = ServiceLocator::get('StageService')->createStage($cachedDbToken->pipeline_id, $stageData);
 
-                ServiceLocator::get('LogService')->log(
+                wpqtTokenLog(
+                    $cachedDbToken->pipeline_id,
                     "Board stage {$stage->name} created by {$apiTokenRepository->getApiTokenName($cachedDbToken)}",
                     [
                         'type'          => WP_QT_LOG_TYPE_PIPELINE,
@@ -256,7 +272,8 @@ function wpqt_register_token_api_routes()
 
                 $editedStage = ServiceLocator::get('StageService')->editStage($request->get_param('stage_id'), $stageData, $cachedDbToken->pipeline_id);
 
-                ServiceLocator::get('LogService')->log(
+                wpqtTokenLog(
+                    $cachedDbToken->pipeline_id,
                     "Board stage {$stage->name} edited by {$apiTokenRepository->getApiTokenName($cachedDbToken)}",
                     [
                         'type'          => WP_QT_LOG_TYPE_PIPELINE,
@@ -320,7 +337,8 @@ function wpqt_register_token_api_routes()
                 }
 
                 ServiceLocator::get('StageService')->deleteStage($request->get_param('stage_id'));
-                ServiceLocator::get('LogService')->log(
+                wpqtTokenLog(
+                    $cachedDbToken->pipeline_id,
                     "Board stage {$stage->name} deleted by {$apiTokenRepository->getApiTokenName($cachedDbToken)}",
                     [
                         'type'          => WP_QT_LOG_TYPE_PIPELINE,
@@ -373,7 +391,8 @@ function wpqt_register_token_api_routes()
                 $apiTokenRepository = ServiceLocator::get('ApiTokenRepository');
                 $tasks = ServiceLocator::get('TaskRepository')->getTasks(['pipeline_id' => $cachedDbToken->pipeline_id, 'is_archived' => false]);
 
-                ServiceLocator::get('LogService')->log(
+                wpqtTokenLog(
+                    $cachedDbToken->pipeline_id,
                     "Board tasks fetched by {$apiTokenRepository->getApiTokenName($cachedDbToken)}",
                     [
                         'type'          => WP_QT_LOG_TYPE_PIPELINE,
@@ -416,7 +435,8 @@ function wpqt_register_token_api_routes()
 
                 $task = ServiceLocator::get('TaskService')->createTask($request->get_param('stage_id'), $taskData);
 
-                ServiceLocator::get('LogService')->log(
+                wpqtTokenLog(
+                    $cachedDbToken->pipeline_id,
                     "Task {$task->name} created by {$apiTokenRepository->getApiTokenName($cachedDbToken)}",
                     [
                         'type'          => WP_QT_LOG_TYPE_TASK,
@@ -515,7 +535,8 @@ function wpqt_register_token_api_routes()
 
                 $taskUpdated = ServiceLocator::get('TaskService')->editTask($taskId, $paramsToUpdate);
 
-                ServiceLocator::get('LogService')->log(
+                wpqtTokenLog(
+                    $cachedDbToken->pipeline_id,
                     "Task {$task->name} updated by {$apiTokenRepository->getApiTokenName($cachedDbToken)}",
                     [
                         'type'          => WP_QT_LOG_TYPE_TASK,
@@ -635,7 +656,8 @@ function wpqt_register_token_api_routes()
                     /* End Handle webhooks */
                 }
 
-                ServiceLocator::get('LogService')->log(
+                wpqtTokenLog(
+                    $cachedDbToken->pipeline_id,
                     "Task {$task->name} order updated by {$apiTokenRepository->getApiTokenName($cachedDbToken)}",
                     [
                         'type'          => WP_QT_LOG_TYPE_TASK,
@@ -707,7 +729,8 @@ function wpqt_register_token_api_routes()
 
                 $changedTask = ServiceLocator::get('TaskService')->changeTaskDoneStatus($task->id, $taskMarkedDoneParam);
 
-                ServiceLocator::get('LogService')->log(
+                wpqtTokenLog(
+                    $cachedDbToken->pipeline_id,
                     "Task {$task->name} marked as " . ($taskMarkedDoneParam ? 'done' : 'not done') . " by {$apiTokenRepository->getApiTokenName($cachedDbToken)}",
                     [
                         'type'          => WP_QT_LOG_TYPE_TASK,
@@ -792,7 +815,8 @@ function wpqt_register_token_api_routes()
                     ]);
                 }
                 ServiceLocator::get('TaskService')->deleteTask($taskId);
-                ServiceLocator::get('LogService')->log(
+                wpqtTokenLog(
+                    $cachedDbToken->pipeline_id,
                     "Task {$task->name} deleted by {$apiTokenRepository->getApiTokenName($cachedDbToken)}",
                     [
                         'type'          => WP_QT_LOG_TYPE_TASK,

--- a/php/constants.php
+++ b/php/constants.php
@@ -60,7 +60,7 @@ DB constants
 */
 
 if (!defined('WP_QUICKTASKER_DB_VERSION')) {
-    define('WP_QUICKTASKER_DB_VERSION', '1.61.0');
+    define('WP_QUICKTASKER_DB_VERSION', '1.62.0');
 }
 
 if (!defined('TABLE_WP_QUICKTASKER_USERS')) {

--- a/php/db.php
+++ b/php/db.php
@@ -250,6 +250,9 @@ if (!function_exists('wpqt_set_up_db')) {
 				public_task_creation_limit int(11) NOT NULL DEFAULT 50,
 				public_task_creation_count int(11) NOT NULL DEFAULT 0,
 				require_logged_in_user tinyint(1) NOT NULL DEFAULT 1,
+				enable_automation_logs tinyint(1) NOT NULL DEFAULT 1,
+				enable_webhook_logs tinyint(1) NOT NULL DEFAULT 1,
+				enable_api_token_logs tinyint(1) NOT NULL DEFAULT 1,
 				PRIMARY KEY  (id),
 				UNIQUE KEY pipeline_id (pipeline_id)
 			) $charset_collate;";

--- a/php/repositories/SettingRepository.php
+++ b/php/repositories/SettingRepository.php
@@ -35,7 +35,7 @@ if (!class_exists('WPQT\Settings\SettingRepository')) {
 
             return $wpdb->get_row(
                 $wpdb->prepare(
-                    'SELECT id, pipeline_id, allow_only_last_stage_task_done, pipeline_refresh_interval, allow_public_task_creation, public_task_creation_limit, public_task_creation_count, require_logged_in_user, created_at, updated_at FROM ' . TABLE_WP_QUICKTASKER_PIPELINE_SETTINGS . ' WHERE pipeline_id = %d',
+                    'SELECT id, pipeline_id, allow_only_last_stage_task_done, pipeline_refresh_interval, allow_public_task_creation, public_task_creation_limit, public_task_creation_count, require_logged_in_user, enable_automation_logs, enable_webhook_logs, enable_api_token_logs, created_at, updated_at FROM ' . TABLE_WP_QUICKTASKER_PIPELINE_SETTINGS . ' WHERE pipeline_id = %d',
                     $pipelineId
                 )
             );
@@ -66,6 +66,18 @@ if (!class_exists('WPQT\Settings\SettingRepository')) {
             return $wpdb->get_row(
                 $wpdb->prepare(
                     'SELECT allow_public_task_creation, public_task_creation_limit, public_task_creation_count, require_logged_in_user FROM ' . TABLE_WP_QUICKTASKER_PIPELINE_SETTINGS . ' WHERE pipeline_id = %d',
+                    $pipelineId
+                )
+            );
+        }
+
+        public function getLogEnabledFlags($pipelineId)
+        {
+            global $wpdb;
+
+            return $wpdb->get_row(
+                $wpdb->prepare(
+                    'SELECT enable_automation_logs, enable_webhook_logs, enable_api_token_logs FROM ' . TABLE_WP_QUICKTASKER_PIPELINE_SETTINGS . ' WHERE pipeline_id = %d',
                     $pipelineId
                 )
             );

--- a/php/services/AutomationService.php
+++ b/php/services/AutomationService.php
@@ -6,6 +6,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+use WPQT\Log\LogService;
 use WPQT\Services\ServiceLocator;
 
 if (!class_exists('WPQT\Automation\AutomationService')) {
@@ -93,6 +94,8 @@ if (!class_exists('WPQT\Automation\AutomationService')) {
 
             $relatedAutomations = ServiceLocator::get('AutomationRepository')->getActiveAutomations($boardId, $targetId, $targetType, $automationTrigger);
             $userId = get_current_user_id();
+            $logService = ServiceLocator::get('LogService');
+            $shouldLog = $logService->shouldLog($boardId, LogService::SOURCE_AUTOMATION);
 
             if (!empty($relatedAutomations)) {
                 foreach ($relatedAutomations as $automation) {
@@ -106,28 +109,32 @@ if (!class_exists('WPQT\Automation\AutomationService')) {
                             } else {
                                 $automation->executionResult = $result;
                             }
-                            $logMessage = $this->getAutomationLogMessage($automation);
-                            ServiceLocator::get('LogService')->log($logMessage, [
+                            if ($shouldLog) {
+                                $logMessage = $this->getAutomationLogMessage($automation);
+                                $logService->log($logMessage, [
+                                    'type'          => $targetType,
+                                    'type_id'       => $targetId,
+                                    'log_status'    => WP_QT_LOG_STATUS_SUCCESS,
+                                    'created_by'    => WP_QT_LOG_CREATED_BY_AUTOMATION,
+                                    'created_by_id' => $automation->id,
+                                    'pipeline_id'   => $boardId,
+                                ]);
+                            }
+                            $executedAutomations[] = $automation;
+                        }
+                    } catch (\Throwable $e) {
+                        $failedAutomations[] = $automation;
+                        if ($shouldLog) {
+                            $failureLogMessage = $this->getAutomationFailedLogMessage($automation) . $e->getMessage();
+                            $logService->log($failureLogMessage, [
                                 'type'          => $targetType,
                                 'type_id'       => $targetId,
-                                'log_status'    => WP_QT_LOG_STATUS_SUCCESS,
+                                'log_status'    => WP_QT_LOG_STATUS_ERROR,
                                 'created_by'    => WP_QT_LOG_CREATED_BY_AUTOMATION,
                                 'created_by_id' => $automation->id,
                                 'pipeline_id'   => $boardId,
                             ]);
-                            $executedAutomations[] = $automation;
                         }
-                    } catch (\Throwable $e) {
-                        $failureLogMessage = $this->getAutomationFailedLogMessage($automation) . $e->getMessage();
-                        $failedAutomations[] = $automation;
-                        ServiceLocator::get('LogService')->log($failureLogMessage, [
-                            'type'          => $targetType,
-                            'type_id'       => $targetId,
-                            'log_status'    => WP_QT_LOG_STATUS_ERROR,
-                            'created_by'    => WP_QT_LOG_CREATED_BY_AUTOMATION,
-                            'created_by_id' => $automation->id,
-                            'pipeline_id'   => $boardId,
-                        ]);
                     }
                 }
             }

--- a/php/services/LogService.php
+++ b/php/services/LogService.php
@@ -11,6 +11,46 @@ use WPQT\Services\ServiceLocator;
 if (!class_exists('WPQT\Log\LogService')) {
     class LogService
     {
+        private $logEnabledFlagsCache = [];
+
+        public const SOURCE_AUTOMATION = 'automation';
+        public const SOURCE_WEBHOOK = 'webhook';
+        public const SOURCE_API_TOKEN = 'api_token';
+
+        /**
+         * Returns true if the given pipeline has logging enabled for the given source.
+         * Sources without a per-board toggle default to true. Missing settings rows
+         * (e.g. legacy boards before the column existed) also default to true to
+         * preserve the prior always-on behavior.
+         */
+        public function shouldLog($pipelineId, $source)
+        {
+            $column = null;
+            if (self::SOURCE_AUTOMATION === $source) {
+                $column = 'enable_automation_logs';
+            } elseif (self::SOURCE_WEBHOOK === $source) {
+                $column = 'enable_webhook_logs';
+            } elseif (self::SOURCE_API_TOKEN === $source) {
+                $column = 'enable_api_token_logs';
+            }
+
+            if (null === $column || empty($pipelineId)) {
+                return true;
+            }
+
+            if (!array_key_exists($pipelineId, $this->logEnabledFlagsCache)) {
+                $this->logEnabledFlagsCache[$pipelineId] = ServiceLocator::get('SettingRepository')->getLogEnabledFlags($pipelineId);
+            }
+
+            $flags = $this->logEnabledFlagsCache[$pipelineId];
+
+            if (null === $flags || !isset($flags->$column)) {
+                return true;
+            }
+
+            return 1 === (int) $flags->$column;
+        }
+
         /**
          * Logs a message to the database.
          *

--- a/php/services/SettingService.php
+++ b/php/services/SettingService.php
@@ -106,6 +106,9 @@ if (!class_exists('WPQT\Settings\SettingsService')) {
                 'public_task_creation_limit',
                 'public_task_creation_count',
                 'require_logged_in_user',
+                'enable_automation_logs',
+                'enable_webhook_logs',
+                'enable_api_token_logs',
             ];
             $updateData = [
                 'updated_at' => ServiceLocator::get('TimeRepository')->getCurrentUTCTime()

--- a/php/services/WebhookService.php
+++ b/php/services/WebhookService.php
@@ -6,6 +6,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+use WPQT\Log\LogService;
 use WPQT\Services\ServiceLocator;
 
 if (!class_exists('WPQT\Webhooks\WebhookService')) {
@@ -97,6 +98,9 @@ if (!class_exists('WPQT\Webhooks\WebhookService')) {
             $eventsFromExecutedAutomations = ServiceLocator::get('WebhookEventService')->constructWebhookEventsFromExecutedAutomations($executedAutomations);
             $allWebhookEvents = array_merge($events, $eventsFromExecutedAutomations);
 
+            $logService = ServiceLocator::get('LogService');
+            $shouldLog = $logService->shouldLog($pipelineId, LogService::SOURCE_WEBHOOK);
+
             foreach ($allWebhookEvents as $event) {
                 if (
                     !isset($event['webhookData']) ||
@@ -122,7 +126,9 @@ if (!class_exists('WPQT\Webhooks\WebhookService')) {
                     ];
 
                     if (!$webhook->active) {
-                        ServiceLocator::get('LogService')->log('Skipped ' . $webHookName . ' because it is inactive', $baseLog);
+                        if ($shouldLog) {
+                            $logService->log('Skipped ' . $webHookName . ' because it is inactive', $baseLog);
+                        }
 
                         continue;
                     }
@@ -130,14 +136,18 @@ if (!class_exists('WPQT\Webhooks\WebhookService')) {
                     try {
                         $this->processWebhook($webhook, $data);
 
-                        ServiceLocator::get('LogService')->log('Executed ' . $webHookName, $baseLog);
+                        if ($shouldLog) {
+                            $logService->log('Executed ' . $webHookName, $baseLog);
+                        }
                     } catch (\Exception $e) {
-                        $errorMessage = $e->getMessage();
-                        $message = 'Error processing ' . $webHookName . ' Reason: ' . $errorMessage;
+                        if ($shouldLog) {
+                            $errorMessage = $e->getMessage();
+                            $message = 'Error processing ' . $webHookName . ' Reason: ' . $errorMessage;
 
-                        ServiceLocator::get('LogService')->log($message, array_merge($baseLog, [
-                          'log_status' => WP_QT_LOG_STATUS_ERROR
-                        ]));
+                            $logService->log($message, array_merge($baseLog, [
+                              'log_status' => WP_QT_LOG_STATUS_ERROR
+                            ]));
+                        }
                     }
                 }
             }

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,7 @@ QuickTasker is a plugin that offers the following and more to organize your proj
 
 = 1.56.0 =
 * Added a "My Tasks" admin page that lists tasks the current user created and tasks assigned to them, gated by a new "Access to My Tasks page" capability.
+* Added per-board toggles in board settings to enable or disable log generation for automations, webhooks and API tokens independently.
 
 = 1.55.0 =
 * Added a Public Task Form Gutenberg block that lets visitors submit tasks to a selected board from any page.

--- a/src/components/Modal/PipelineModal/components/LogGenerationSetting/LogGenerationSetting.tsx
+++ b/src/components/Modal/PipelineModal/components/LogGenerationSetting/LogGenerationSetting.tsx
@@ -1,0 +1,90 @@
+import { useState } from "@wordpress/element";
+import { __ } from "@wordpress/i18n";
+import { useSettingActions } from "../../../../../hooks/actions/useSettingActions";
+import { PipelineSettings } from "../../../../../types/pipeline-settings";
+import { Toggle } from "../../../../common/Toggle/Toggle";
+import { LoadingOval } from "../../../../Loading/Loading";
+import { Settings } from "../Setting/Settings";
+
+type Props = {
+  pipelineId: string;
+  enableAutomationLogs: boolean;
+  enableWebhookLogs: boolean;
+  enableApiTokenLogs: boolean;
+};
+
+type Source = "automation" | "webhook" | "api_token";
+
+function LogGenerationSetting({
+  pipelineId,
+  enableAutomationLogs,
+  enableWebhookLogs,
+  enableApiTokenLogs,
+}: Props) {
+  const [enabled, setEnabled] = useState({
+    automation: enableAutomationLogs,
+    webhook: enableWebhookLogs,
+    api_token: enableApiTokenLogs,
+  });
+  const [saving, setSaving] = useState<Source | null>(null);
+  const { savePipelineSettings } = useSettingActions();
+
+  const settingKey: Record<Source, keyof PipelineSettings> = {
+    automation: "enable_automation_logs",
+    webhook: "enable_webhook_logs",
+    api_token: "enable_api_token_logs",
+  };
+
+  const onToggle = (source: Source) => async (checked: boolean) => {
+    setEnabled((prev) => ({ ...prev, [source]: checked }));
+    setSaving(source);
+    const { success } = await savePipelineSettings(pipelineId, {
+      [settingKey[source]]: checked,
+    });
+    setSaving(null);
+
+    if (!success) {
+      setEnabled((prev) => ({ ...prev, [source]: !checked }));
+    }
+  };
+
+  const row = (source: Source, label: string, testId: string): JSX.Element => (
+    <div className="wpqt-flex wpqt-gap-2 wpqt-items-center wpqt-mb-2">
+      <Toggle
+        checked={enabled[source]}
+        handleChange={onToggle(source)}
+        dataTestId={testId}
+      />
+      <span>{label}</span>
+      {saving === source && <LoadingOval width="20" height="20" />}
+    </div>
+  );
+
+  return (
+    <Settings
+      title={__("Log generation", "quicktasker")}
+      description={__(
+        "Choose which sources may write entries to this board's activity log. Disable a source to stop it from generating logs when it produces too much noise.",
+        "quicktasker",
+      )}
+    >
+      {row(
+        "automation",
+        __("Automation logs", "quicktasker"),
+        "enable-automation-logs-toggle",
+      )}
+      {row(
+        "webhook",
+        __("Webhook logs", "quicktasker"),
+        "enable-webhook-logs-toggle",
+      )}
+      {row(
+        "api_token",
+        __("API token logs", "quicktasker"),
+        "enable-api-token-logs-toggle",
+      )}
+    </Settings>
+  );
+}
+
+export { LogGenerationSetting };

--- a/src/components/Modal/PipelineModal/components/PipelineSettings/PipelineSettings.tsx
+++ b/src/components/Modal/PipelineModal/components/PipelineSettings/PipelineSettings.tsx
@@ -5,6 +5,7 @@ import { Pipeline } from "../../../../../types/pipeline";
 import { PipelineSettings } from "../../../../../types/pipeline-settings";
 import { convertPipelineSettingsFromServer } from "../../../../../utils/pipeline-settings";
 import { Loading } from "../../../../Loading/Loading";
+import { LogGenerationSetting } from "../LogGenerationSetting/LogGenerationSetting";
 import { PipelineRefreshIntervalSetting } from "../PipelineRefreshIntervalSetting/PipelineRefreshIntervalSetting";
 import { PublicTaskSubmissionsSetting } from "../PublicTaskSubmissionsSetting/PublicTaskSubmissionsSetting";
 import { TaskCompletionDoneSetting } from "../TaskCompletionDoneSetting/TaskCompletionDoneSetting";
@@ -59,6 +60,12 @@ function PipelineSettings({ pipeline }: Props) {
         publicTaskCreationLimit={settings.public_task_creation_limit}
         publicTaskCreationCount={settings.public_task_creation_count}
         requireLoggedInUser={settings.require_logged_in_user}
+      />
+      <LogGenerationSetting
+        pipelineId={pipeline.id}
+        enableAutomationLogs={settings.enable_automation_logs}
+        enableWebhookLogs={settings.enable_webhook_logs}
+        enableApiTokenLogs={settings.enable_api_token_logs}
       />
     </div>
   );

--- a/src/pages/PipelinePage/components/PipelineHeader/PipelineHeader.tsx
+++ b/src/pages/PipelinePage/components/PipelineHeader/PipelineHeader.tsx
@@ -29,7 +29,10 @@ function PipelineHeader() {
     <div className="wpqt-flex wpqt-items-center wpqt-gap-2 wpqt-py-5">
       <div>
         <div className="wpqt-flex wpqt-items-center wpqt-gap-2">
-          <div className="wpqt-text-lg wpqt-font-semibold">
+          <div
+            className="wpqt-text-lg wpqt-font-semibold"
+            data-testid="active-pipeline-name"
+          >
             {activePipeline.name}
           </div>
         </div>

--- a/src/types/pipeline-settings.ts
+++ b/src/types/pipeline-settings.ts
@@ -10,6 +10,9 @@ type PipelineSettings = BasePipelineSettings & {
   public_task_creation_limit: number;
   public_task_creation_count: number;
   require_logged_in_user: boolean;
+  enable_automation_logs: boolean;
+  enable_webhook_logs: boolean;
+  enable_api_token_logs: boolean;
 };
 
 type PipelineSettingsFromServer = BasePipelineSettings & {
@@ -19,6 +22,9 @@ type PipelineSettingsFromServer = BasePipelineSettings & {
   public_task_creation_limit: string;
   public_task_creation_count: string;
   require_logged_in_user: string;
+  enable_automation_logs: string;
+  enable_webhook_logs: string;
+  enable_api_token_logs: string;
 };
 
 type PublicPipelineSettings = {

--- a/src/utils/pipeline-settings.test.ts
+++ b/src/utils/pipeline-settings.test.ts
@@ -21,6 +21,9 @@ describe("pipeline-settings", () => {
       public_task_creation_limit: "0",
       public_task_creation_count: "0",
       require_logged_in_user: "1",
+      enable_automation_logs: "1",
+      enable_webhook_logs: "1",
+      enable_api_token_logs: "1",
       ...overrides,
     });
 
@@ -133,6 +136,9 @@ describe("pipeline-settings", () => {
         public_task_creation_limit: 0,
         public_task_creation_count: 0,
         require_logged_in_user: true,
+        enable_automation_logs: true,
+        enable_webhook_logs: true,
+        enable_api_token_logs: true,
       });
     });
 
@@ -155,6 +161,33 @@ describe("pipeline-settings", () => {
       const result = convertPipelineSettingsFromServer(serverSettings);
 
       expect(result.require_logged_in_user).toBe(true);
+    });
+
+    it.each([
+      ["enable_automation_logs"],
+      ["enable_webhook_logs"],
+      ["enable_api_token_logs"],
+    ] as const)("should convert %s from '0' to false", (field) => {
+      const serverSettings = createMockPipelineSettingsFromServer({
+        [field]: "0",
+      });
+
+      const result = convertPipelineSettingsFromServer(serverSettings);
+
+      expect(result[field]).toBe(false);
+    });
+
+    it.each([
+      ["enable_automation_logs"],
+      ["enable_webhook_logs"],
+      ["enable_api_token_logs"],
+    ] as const)("should default %s to true when missing", (field) => {
+      const serverSettings = createMockPipelineSettingsFromServer();
+      delete (serverSettings as Partial<PipelineSettingsFromServer>)[field];
+
+      const result = convertPipelineSettingsFromServer(serverSettings);
+
+      expect(result[field]).toBe(true);
     });
   });
 

--- a/src/utils/pipeline-settings.ts
+++ b/src/utils/pipeline-settings.ts
@@ -31,6 +31,18 @@ const convertPipelineSettingsFromServer = (
       pipelineSettings.require_logged_in_user === undefined
         ? true
         : pipelineSettings.require_logged_in_user === "1",
+    enable_automation_logs:
+      pipelineSettings.enable_automation_logs === undefined
+        ? true
+        : pipelineSettings.enable_automation_logs === "1",
+    enable_webhook_logs:
+      pipelineSettings.enable_webhook_logs === undefined
+        ? true
+        : pipelineSettings.enable_webhook_logs === "1",
+    enable_api_token_logs:
+      pipelineSettings.enable_api_token_logs === undefined
+        ? true
+        : pipelineSettings.enable_api_token_logs === "1",
   };
 };
 

--- a/tests/e2e/log-generation-settings.spec.ts
+++ b/tests/e2e/log-generation-settings.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect, Page } from '@playwright/test';
+import { navigateToBoardsPage } from './utils/navigation';
+import { createBoard, generateUniqueName, getTaskCard, selectBoard } from './utils/board-helpers';
+import {
+  createTaskAutomation,
+  enableAutomation,
+  navigateToAutomationsPage,
+  openFirstAutomationLogs,
+  setupBoardForAutomations,
+} from './utils/automation-helpers';
+import { TIMEOUTS } from './utils/timeouts';
+
+async function openBoardSettings(page: Page): Promise<void> {
+  await page.locator('#wpqt-app').getByText('Settings').first().click();
+  await expect(page.getByTestId('edit-pipeline-modal')).toBeVisible();
+}
+
+async function ensureAutomationLogsOff(page: Page): Promise<void> {
+  const input = page.getByTestId('enable-automation-logs-toggle');
+  await expect(input).toBeChecked();
+  await input.scrollIntoViewIfNeeded();
+  const bg = input.locator('xpath=..').locator('.react-switch-bg').first();
+  await bg.waitFor({ state: 'visible' });
+  await bg.click();
+  await expect(input).not.toBeChecked();
+  await page.waitForTimeout(1500);
+}
+
+test.describe('Board log generation settings', () => {
+  test.beforeEach(async ({ page }) => {
+    await navigateToBoardsPage(page);
+  });
+
+  test('shows three log generation toggles with on defaults inside board settings', async ({ page }) => {
+    await createBoard(page, generateUniqueName('LG-Defaults-Board'));
+    await openBoardSettings(page);
+
+    await expect(page.getByText('Log generation')).toBeVisible();
+    await expect(page.getByTestId('enable-automation-logs-toggle')).toBeChecked();
+    await expect(page.getByTestId('enable-webhook-logs-toggle')).toBeChecked();
+    await expect(page.getByTestId('enable-api-token-logs-toggle')).toBeChecked();
+  });
+
+  test('persists the API token logs toggle across reloads', async ({ page }) => {
+    const boardName = generateUniqueName('LG-Persist-Board');
+    await createBoard(page, boardName);
+
+    await openBoardSettings(page);
+    const apiTokenInput = page.getByTestId('enable-api-token-logs-toggle');
+    await apiTokenInput.locator('xpath=..').locator('.react-switch-bg').first().click();
+    await expect(apiTokenInput).not.toBeChecked();
+    await page.waitForTimeout(1500);
+
+    await page.reload();
+
+    await page.getByTestId('pipeline-selection-dropdown').click();
+    const boardMenuItem = page.locator('.wpqt-mb-3').filter({ hasText: boardName });
+    await boardMenuItem.getByText(boardName).click();
+    await expect(page.getByTestId('active-pipeline-name')).toHaveText(boardName);
+
+    await openBoardSettings(page);
+
+    await expect(page.getByTestId('enable-api-token-logs-toggle')).not.toBeChecked();
+    await expect(page.getByTestId('enable-automation-logs-toggle')).toBeChecked();
+    await expect(page.getByTestId('enable-webhook-logs-toggle')).toBeChecked();
+  });
+
+  test('writes an automation log when automation logs are enabled', async ({ page }) => {
+    test.setTimeout(TIMEOUTS.LONG_TEST);
+    const { boardName, taskName } = await setupBoardForAutomations(page, 'LG-AutoOn');
+
+    await createTaskAutomation(page, 'Task marked as done', 'Archive task');
+    await enableAutomation(page);
+
+    await navigateToBoardsPage(page);
+    await selectBoard(page, boardName);
+    await getTaskCard(page, taskName).getByTestId('task-done-icon-uncompleted').click();
+    await page.waitForTimeout(1000);
+
+    await navigateToAutomationsPage(page);
+    await openFirstAutomationLogs(page);
+
+    await expect(page.getByTestId('automation-logs-modal')).toContainText('Automation executed');
+    await expect(page.getByTestId('automation-logs-modal')).not.toContainText('No logs found');
+  });
+
+  test('does not write an automation log when automation logs are disabled', async ({ page }) => {
+    test.setTimeout(TIMEOUTS.LONG_TEST);
+    const { boardName, taskName } = await setupBoardForAutomations(page, 'LG-AutoOff');
+
+    await createTaskAutomation(page, 'Task marked as done', 'Archive task');
+    await enableAutomation(page);
+
+    await navigateToBoardsPage(page);
+    await selectBoard(page, boardName);
+    await expect(page.getByTestId('active-pipeline-name')).toHaveText(boardName);
+    await openBoardSettings(page);
+    await ensureAutomationLogsOff(page);
+    await page.keyboard.press('Escape');
+
+    await getTaskCard(page, taskName).getByTestId('task-done-icon-uncompleted').click();
+    await page.waitForTimeout(1000);
+
+    await navigateToAutomationsPage(page);
+    await openFirstAutomationLogs(page);
+
+    await expect(page.getByTestId('automation-logs-modal')).toContainText('No logs found');
+  });
+});

--- a/tests/unit/be/services/LogServiceTest.php
+++ b/tests/unit/be/services/LogServiceTest.php
@@ -15,10 +15,12 @@ if (!defined('WP_QT_LOG_CREATED_BY_SYSTEM')) {
     define('WP_QT_LOG_CREATED_BY_SYSTEM', 'system');
 }
 
+require_once __DIR__ . '/../../../../php/services/ServiceLocator.php';
 require_once __DIR__ . '/../../../../php/services/LogService.php';
 
 use PHPUnit\Framework\TestCase;
 use WPQT\Log\LogService;
+use WPQT\Services\ServiceLocator;
 
 /**
  * Test suite for LogService
@@ -198,6 +200,63 @@ class LogServiceTest extends TestCase {
      * - Test default values are applied correctly
      * - Test error handling with Exception messages
      */
+    public function testShouldLogReturnsTrueWhenPipelineIdIsEmpty(): void {
+        $this->assertTrue($this->service->shouldLog(null, LogService::SOURCE_AUTOMATION));
+        $this->assertTrue($this->service->shouldLog(0, LogService::SOURCE_WEBHOOK));
+    }
+
+    public function testShouldLogReturnsTrueForUnknownSource(): void {
+        $this->assertTrue($this->service->shouldLog(123, 'unknown-source'));
+    }
+
+    public function testShouldLogReturnsTrueWhenSettingsRowMissing(): void {
+        $settingRepo = $this->getMockBuilder(stdClass::class)
+            ->addMethods(['getLogEnabledFlags'])
+            ->getMock();
+        $settingRepo->method('getLogEnabledFlags')->willReturn(null);
+        ServiceLocator::register('SettingRepository', $settingRepo);
+
+        $service = new LogService();
+        $this->assertTrue($service->shouldLog(42, LogService::SOURCE_API_TOKEN));
+    }
+
+    public function testShouldLogReturnsFalseWhenFlagDisabled(): void {
+        $settingRepo = $this->getMockBuilder(stdClass::class)
+            ->addMethods(['getLogEnabledFlags'])
+            ->getMock();
+        $settingRepo->method('getLogEnabledFlags')->willReturn((object) [
+            'enable_automation_logs' => '1',
+            'enable_webhook_logs'    => '1',
+            'enable_api_token_logs'  => '0',
+        ]);
+        ServiceLocator::register('SettingRepository', $settingRepo);
+
+        $service = new LogService();
+        $this->assertFalse($service->shouldLog(42, LogService::SOURCE_API_TOKEN));
+        $this->assertTrue($service->shouldLog(42, LogService::SOURCE_AUTOMATION));
+        $this->assertTrue($service->shouldLog(42, LogService::SOURCE_WEBHOOK));
+    }
+
+    public function testShouldLogCachesPerPipelineLookup(): void {
+        $settingRepo = $this->getMockBuilder(stdClass::class)
+            ->addMethods(['getLogEnabledFlags'])
+            ->getMock();
+        $settingRepo->expects($this->once())
+            ->method('getLogEnabledFlags')
+            ->with(7)
+            ->willReturn((object) [
+                'enable_automation_logs' => '0',
+                'enable_webhook_logs'    => '1',
+                'enable_api_token_logs'  => '1',
+            ]);
+        ServiceLocator::register('SettingRepository', $settingRepo);
+
+        $service = new LogService();
+        $service->shouldLog(7, LogService::SOURCE_AUTOMATION);
+        $service->shouldLog(7, LogService::SOURCE_WEBHOOK);
+        $service->shouldLog(7, LogService::SOURCE_API_TOKEN);
+    }
+
     public function testLogRequiresIntegrationTest(): void {
         $this->markTestIncomplete(
             'log() requires $wpdb, wp_parse_args(), ServiceLocator (TimeRepository, LogRepository). ' .


### PR DESCRIPTION
## Summary
- Adds three per-board toggles (automations, webhooks, API tokens) in board settings to control whether each source writes to the activity log. Defaults to ON so existing behavior is preserved.
- Gates `LogService::log()` calls in `AutomationService`, `WebhookService` and `token-api.php` behind a new `LogService::shouldLog($pipelineId, $source)` check (cached per-request).
- Adds `enable_automation_logs`, `enable_webhook_logs`, `enable_api_token_logs` columns to the pipeline settings table via `dbDelta`.