### PR TITLE
Add mobile responsiveness to admin pages

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -3,7 +3,7 @@
 # List of files and directories to remove
 FILES_TO_REMOVE=(
     "tsconfig.json"
-    ".eslint.config.js"
+    "eslint.config.js"
     ".prettierrc"
     ".vscode"
     ".github"

--- a/quicktasker.php
+++ b/quicktasker.php
@@ -2,6 +2,7 @@
 
 /*
     Plugin Name: QuickTasker
+    Plugin URI: https://github.com/SiimKirjanen/quicktasker
     Description: Task management plugin designed to help you organize your projects, streamline workflows, and get tasks done efficiently.
     Author: Siim Kirjanen
     Author URI: https://github.com/SiimKirjanen

--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,7 @@ Task management plugin designed to help you organize your projects, streamline w
 
 == Description ==
 
-QuickTasker is a kanban-style task management plugin for WordPress. Organize work into boards and stages, collaborate with WordPress users or dedicated QuickTasker users, and extend your workflow with automations, webhooks, and an API.
+QuickTasker is an open source kanban-style task management plugin for WordPress. Organize work into boards and stages, collaborate with WordPress users or dedicated QuickTasker users, and extend your workflow with automations, webhooks, and an API.
 
 = Organize your work =
 * Create boards with multiple stages and move tasks between them to track progress.

--- a/src/components/LogsTable/LogsTable.tsx
+++ b/src/components/LogsTable/LogsTable.tsx
@@ -6,22 +6,24 @@ import { logCreatedByString } from "../../utils/log";
 
 function LogsTable({ logs }: { logs: Log[] }) {
   return (
-    <div className="wpqt-inline-grid wpqt-grid-cols-[auto_auto_auto_auto] wpqt-items-center wpqt-gap-x-8 wpqt-gap-y-3">
-      <div className="wpqt-mb-2 wpqt-font-bold">
-        {__("Status", "quicktasker")}
+    <div className="wpqt-overflow-x-auto">
+      <div className="wpqt-inline-grid wpqt-min-w-[640px] wpqt-grid-cols-[auto_auto_auto_auto] wpqt-items-center wpqt-gap-x-8 wpqt-gap-y-3">
+        <div className="wpqt-mb-2 wpqt-font-bold">
+          {__("Status", "quicktasker")}
+        </div>
+        <div className="wpqt-mb-2 wpqt-font-bold">
+          {__("Created at", "quicktasker")}
+        </div>
+        <div className="wpqt-mb-2 wpqt-font-bold">
+          {__("Author", "quicktasker")}
+        </div>
+        <div className="wpqt-mb-2 wpqt-font-bold">
+          {__("Message", "quicktasker")}
+        </div>
+        {logs.map((log) => (
+          <LogRow log={log} key={log.id} />
+        ))}
       </div>
-      <div className="wpqt-mb-2 wpqt-font-bold">
-        {__("Created at", "quicktasker")}
-      </div>
-      <div className="wpqt-mb-2 wpqt-font-bold">
-        {__("Author", "quicktasker")}
-      </div>
-      <div className="wpqt-mb-2 wpqt-font-bold">
-        {__("Message", "quicktasker")}
-      </div>
-      {logs.map((log) => (
-        <LogRow log={log} key={log.id} />
-      ))}
     </div>
   );
 }

--- a/src/components/Modal/TaskModal/TaskModalContent.tsx
+++ b/src/components/Modal/TaskModal/TaskModalContent.tsx
@@ -105,8 +105,8 @@ const TaskModalContent = ({ deleteTask }: Props) => {
 
   return (
     <>
-      <div className="wpqt-grid wpqt-grid-cols-1 wpqt-gap-7 md:wpqt-grid-cols-[1fr_auto]">
-        <div className="wpqt-border-0 wpqt-border-r wpqt-border-solid wpqt-border-r-gray-300 md:wpqt-pr-6">
+      <div className="wpqt-grid wpqt-grid-cols-1 wpqt-gap-7 lg:wpqt-grid-cols-[1fr_auto]">
+        <div className="wpqt-border-0 lg:wpqt-border-r lg:wpqt-border-solid lg:wpqt-border-r-gray-300 lg:wpqt-pr-6">
           <WPQTTabs
             tabs={[
               { name: __("Details", "quicktasker") },
@@ -115,7 +115,7 @@ const TaskModalContent = ({ deleteTask }: Props) => {
             tabClassName="!wpqt-flex-none wpqt-px-4 wpqt-text-left wpqt-font-semibold wpqt-text-gray-400 hover:wpqt-text-gray-600 data-[selected]:wpqt-text-blue-600 data-[selected]:!wpqt-border-b-[3px]"
             tabsContent={[
               <div key="details">
-                <div className="wpqt-mb-2 wpqt-grid wpqt-grid-cols-1 wpqt-gap-10 md:wpqt-grid-cols-[1fr_0.7fr]">
+                <div className="wpqt-mb-2 wpqt-grid wpqt-grid-cols-1 wpqt-gap-10 lg:wpqt-grid-cols-[1fr_0.7fr]">
                   <WPQTModalFieldSet>
                     <WPQTModalField label={__("Name", "quicktasker")}>
                       <AutoSaveInput
@@ -235,14 +235,14 @@ const TaskModalContent = ({ deleteTask }: Props) => {
                   />
                 </WPQTModalField>
               </div>,
-              <div key="comments" className="md:wpqt-pr-3">
+              <div key="comments" className="lg:wpqt-pr-3">
                 <TaskComments taskId={taskToEdit.id} />
               </div>,
             ]}
           />
         </div>
 
-        <div className="wpqt-flex wpqt-flex-col wpqt-gap-2">
+        <div className="wpqt-flex wpqt-flex-wrap wpqt-justify-end wpqt-gap-2 lg:wpqt-flex-col lg:wpqt-justify-start">
           <WPQTIconButton
             icon={<TbLogs className="wpqt-icon-blue wpqt-size-5" />}
             text={__("View logs", "quicktasker")}

--- a/src/components/Modal/WPQTModal.tsx
+++ b/src/components/Modal/WPQTModal.tsx
@@ -45,10 +45,10 @@ function WPQTModal({
           <DialogPanel
             transition
             data-testid={testId}
-            className={`data-[closed]:wpqt-transform-[wpqt-scale(95%)] wpqt-relative wpqt-mt-[20px] wpqt-w-4/5 ${sizeClasses[size]} wpqt-rounded-xl wpqt-bg-white wpqt-p-8 wpqt-backdrop-blur-2xl wpqt-duration-300 wpqt-ease-out data-[closed]:wpqt-opacity-0`}
+            className={`data-[closed]:wpqt-transform-[wpqt-scale(95%)] wpqt-relative wpqt-mt-[20px] wpqt-w-[95%] sm:wpqt-w-4/5 ${sizeClasses[size]} wpqt-rounded-xl wpqt-bg-white wpqt-p-4 sm:wpqt-p-8 wpqt-backdrop-blur-2xl wpqt-duration-300 wpqt-ease-out data-[closed]:wpqt-opacity-0`}
           >
             <div
-              className="wpqt-group wpqt-absolute wpqt-right-[-20px] wpqt-top-[-20px] wpqt-flex wpqt-h-[40px] wpqt-w-[40px] wpqt-cursor-pointer wpqt-items-center wpqt-justify-center wpqt-rounded-full wpqt-border wpqt-border-solid wpqt-bg-white wpqt-text-qtBorder"
+              className="wpqt-group wpqt-absolute wpqt-right-2 wpqt-top-2 sm:wpqt-right-[-20px] sm:wpqt-top-[-20px] wpqt-flex wpqt-h-[40px] wpqt-w-[40px] wpqt-cursor-pointer wpqt-items-center wpqt-justify-center wpqt-rounded-full wpqt-border wpqt-border-solid wpqt-bg-white wpqt-text-qtBorder"
               onClick={closeModal}
               data-testid="wpqt-modal-close-button"
             >

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -15,19 +15,19 @@ function WPQTPageHeader({
   readMoreLink = null,
 }: WPQTPageHeaderProps) {
   return (
-    <div className="wpqt-flex wpqt-flex-col wpqt-mb-6 wpqt-mt-6 wpqt-gap-3">
-      <div className="wpqt-flex wpqt-items-center">
-        <h1 className="wpqt-m-0">
-          {children}
-          {icon && <span className="wpqt-ml-1 wpqt-align-middle">{icon}</span>}
-        </h1>
-        {rightSideContent && (
-          <div className="wpqt-ml-auto">{rightSideContent}</div>
-        )}
-      </div>
-      <div className="wpqt-whitespace-pre-line">
+    <div className="wpqt-flex wpqt-flex-col wpqt-mb-6 wpqt-mt-6 wpqt-gap-3 lg:wpqt-grid lg:wpqt-grid-cols-[1fr_auto] lg:wpqt-gap-x-4">
+      <h1 className="wpqt-m-0">
+        {children}
+        {icon && <span className="wpqt-ml-1 wpqt-align-middle">{icon}</span>}
+      </h1>
+      <div className="wpqt-whitespace-pre-line lg:wpqt-col-start-1 lg:wpqt-row-start-2">
         {description} {readMoreLink}
       </div>
+      {rightSideContent && (
+        <div className="lg:wpqt-col-start-2 lg:wpqt-row-start-1 lg:wpqt-row-span-2 lg:wpqt-self-center">
+          {rightSideContent}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,7 @@
-import { render } from "@wordpress/element";
+import { createRoot } from "@wordpress/element";
 import App from "./App";
 
-render(<App />, document.getElementById("wpqt-app"));
+const container = document.getElementById("wpqt-app");
+if (container) {
+  createRoot(container).render(<App />);
+}

--- a/src/pages/ApiTokensPage/ApiTokensPage.tsx
+++ b/src/pages/ApiTokensPage/ApiTokensPage.tsx
@@ -51,7 +51,7 @@ function ApiTokensPageContent({ pipelineId }: ApiTokensPageContentProps) {
 
   if (isEmpty) {
     return (
-      <div className="wpqt-max-w-[460px] wpqt-mx-auto wpqt-mt-12 wpqt-border wpqt-border-solid wpqt-border-qtBorder wpqt-rounded-md wpqt-p-6">
+      <div className="wpqt-box-border wpqt-max-w-[460px] wpqt-mx-auto wpqt-mt-12 wpqt-border wpqt-border-solid wpqt-border-qtBorder wpqt-rounded-md wpqt-p-6">
         <h2 className="wpqt-mt-0">
           {__("Create a new API token", "quicktasker")}
         </h2>
@@ -68,13 +68,13 @@ function ApiTokensPageContent({ pipelineId }: ApiTokensPageContentProps) {
   }
 
   return (
-    <div className="wpqt-flex wpqt-flex-col lg:wpqt-flex-row wpqt-gap-16">
+    <div className="wpqt-flex wpqt-flex-col lg:wpqt-flex-row wpqt-gap-6 lg:wpqt-gap-16">
       <div className="wpqt-flex-1 wpqt-min-w-0">
         <h2>{__("Created API tokens", "quicktasker")}</h2>
         <PipelineApiTokensInfo />
         <PipelineApiTokens />
       </div>
-      <div className="lg:wpqt-w-[460px] lg:wpqt-shrink-0 wpqt-border wpqt-border-solid wpqt-border-qtBorder wpqt-rounded-md wpqt-p-6 wpqt-self-start">
+      <div className="wpqt-box-border wpqt-w-full wpqt-min-w-0 lg:wpqt-w-[460px] lg:wpqt-shrink-0 wpqt-border wpqt-border-solid wpqt-border-qtBorder wpqt-rounded-md wpqt-p-6 wpqt-self-start">
         <h2 className="wpqt-mt-0">
           {__("Create a new API token", "quicktasker")}
         </h2>
@@ -120,8 +120,8 @@ function ApiTokensPage({ pipelineId }: ApiTokensPageProps) {
               </a>
             }
             rightSideContent={
-              <div className="wpqt-flex wpqt-items-center wpqt-gap-6">
-                <div className="wpqt-flex wpqt-flex-col wpqt-gap-2 wpqt-mr-2 wpqt-pr-4 wpqt-border-0 wpqt-border-r wpqt-border-solid wpqt-border-qtBorder">
+              <div className="wpqt-flex wpqt-flex-wrap wpqt-items-center wpqt-gap-3 sm:wpqt-gap-6">
+                <div className="wpqt-flex wpqt-flex-col wpqt-gap-2 sm:wpqt-mr-2 sm:wpqt-pr-4 sm:wpqt-border-0 sm:wpqt-border-r sm:wpqt-border-solid sm:wpqt-border-qtBorder">
                   <div className="wpqt-flex wpqt-items-center wpqt-gap-6">
                     <div
                       className="wpqt-flex wpqt-items-center wpqt-cursor-pointer wpqt-gap-2 wpqt-group"
@@ -190,7 +190,7 @@ function RefreshApiTokens() {
   const { loading, refetchPipelineApiTokens } = useApiTokens();
 
   return (
-    <div className="wpqt-mx-5">
+    <div className="wpqt-mx-2 sm:wpqt-mx-5">
       {loading ? (
         <LoadingOval width="28" height="28" />
       ) : (

--- a/src/pages/AutomationsPage/AutomationsPage.tsx
+++ b/src/pages/AutomationsPage/AutomationsPage.tsx
@@ -47,7 +47,7 @@ function AutomationsPageContent({ pipelineId }: Props) {
 
   if (isEmpty) {
     return (
-      <div className="wpqt-max-w-[460px] wpqt-mx-auto wpqt-mt-12 wpqt-border wpqt-border-solid wpqt-border-qtBorder wpqt-rounded-md wpqt-p-6">
+      <div className="wpqt-box-border wpqt-max-w-[460px] wpqt-mx-auto wpqt-mt-12 wpqt-border wpqt-border-solid wpqt-border-qtBorder wpqt-rounded-md wpqt-p-6">
         <h2 className="wpqt-mt-0">
           {__("Create a new automation", "quicktasker")}
         </h2>
@@ -61,13 +61,13 @@ function AutomationsPageContent({ pipelineId }: Props) {
   }
 
   return (
-    <div className="wpqt-flex wpqt-flex-col lg:wpqt-flex-row wpqt-gap-16">
+    <div className="wpqt-flex wpqt-flex-col lg:wpqt-flex-row wpqt-gap-6 lg:wpqt-gap-16">
       <div className="wpqt-flex-1 wpqt-min-w-0">
         <h2>{__("Created automations", "quicktasker")}</h2>
         <PipelineAutomationsInfo />
         <PipelineAutomations />
       </div>
-      <div className="lg:wpqt-w-[460px] lg:wpqt-shrink-0 wpqt-border wpqt-border-solid wpqt-border-qtBorder wpqt-rounded-md wpqt-p-6 wpqt-self-start">
+      <div className="wpqt-box-border wpqt-w-full wpqt-min-w-0 lg:wpqt-w-[460px] lg:wpqt-shrink-0 wpqt-border wpqt-border-solid wpqt-border-qtBorder wpqt-rounded-md wpqt-p-6 wpqt-self-start">
         <h2 className="wpqt-mt-0">
           {__("Create a new automation", "quicktasker")}
         </h2>
@@ -98,8 +98,8 @@ function AutomationsPage({ pipelineId }: Props) {
               "quicktasker",
             )}
             rightSideContent={
-              <div className="wpqt-flex wpqt-items-center wpqt-gap-6">
-                <div className="wpqt-flex wpqt-flex-col wpqt-gap-2 wpqt-mr-2 wpqt-pr-4 wpqt-border-0 wpqt-border-r wpqt-border-solid wpqt-border-qtBorder">
+              <div className="wpqt-flex wpqt-flex-wrap wpqt-items-center wpqt-gap-3 sm:wpqt-gap-6">
+                <div className="wpqt-flex wpqt-flex-col wpqt-gap-2 sm:wpqt-mr-2 sm:wpqt-pr-4 sm:wpqt-border-0 sm:wpqt-border-r sm:wpqt-border-solid sm:wpqt-border-qtBorder">
                   <div className="wpqt-flex wpqt-items-center wpqt-gap-6">
                     <div
                       className="wpqt-flex wpqt-items-center wpqt-cursor-pointer wpqt-gap-2 wpqt-group"
@@ -168,7 +168,7 @@ function RefreshAutomations() {
   const { loading, refetchPipelineAutomations } = useAutomations();
 
   return (
-    <div className="wpqt-mx-5">
+    <div className="wpqt-mx-2 sm:wpqt-mx-5">
       {loading ? (
         <LoadingOval width="28" height="28" />
       ) : (

--- a/src/pages/MyTasksPage/components/MyTasksHeaderControls.tsx
+++ b/src/pages/MyTasksPage/components/MyTasksHeaderControls.tsx
@@ -29,23 +29,23 @@ function MyTasksHeaderControls({
   onRefresh,
 }: Props) {
   return (
-    <div className="wpqt-flex wpqt-items-center wpqt-gap-4">
+    <div className="wpqt-flex wpqt-flex-wrap wpqt-items-center wpqt-gap-3 sm:wpqt-gap-4">
       <WPQTSelect
         options={boardOptions}
         selectedOptionValue={boardFilter}
         onSelectionChange={onBoardFilterChange}
         allSelectorLabel={__("All boards", "quicktasker")}
-        className="!wpqt-h-[30px] !wpqt-min-h-[30px] !wpqt-py-0 !wpqt-pl-2 !wpqt-pr-6 !wpqt-text-sm/6 !wpqt-border-[#8c8f94] !wpqt-shadow-none"
+        className="!wpqt-h-[30px] !wpqt-min-h-[30px] !wpqt-py-[0px] !wpqt-pl-2 !wpqt-pr-6 !wpqt-text-sm/6 !wpqt-leading-[28px] !wpqt-shadow-none"
       />
       <WPQTInput
         value={searchValue}
         onChange={onSearchChange}
         placeholder={__("Search tasks", "quicktasker")}
-        className="wpqt-w-52"
+        className="wpqt-w-52 !wpqt-border-qtBorder"
         wrapperClassName="!wpqt-mb-0"
         leftIcon={<MagnifyingGlassIcon className="wpqt-size-4" />}
       />
-      <div className="wpqt-mx-5">
+      <div className="wpqt-mx-2 sm:wpqt-mx-5">
         {loading ? (
           <LoadingOval width="28" height="28" />
         ) : (

--- a/src/pages/OverviewPage/OverviewPage.tsx
+++ b/src/pages/OverviewPage/OverviewPage.tsx
@@ -57,8 +57,8 @@ function OverviewPage({ pipelineId }: Props) {
         <WPQTPageHeader
           description={__("Get overview of the board.", "quicktasker")}
           rightSideContent={
-            <div className="wpqt-flex wpqt-items-center wpqt-gap-6">
-              <div className="wpqt-flex wpqt-flex-col wpqt-gap-2 wpqt-mr-2 wpqt-pr-4 wpqt-border-0 wpqt-border-r wpqt-border-solid wpqt-border-qtBorder">
+            <div className="wpqt-flex wpqt-flex-wrap wpqt-items-center wpqt-gap-3 sm:wpqt-gap-6">
+              <div className="wpqt-flex wpqt-flex-col wpqt-gap-2 sm:wpqt-mr-2 sm:wpqt-pr-4 sm:wpqt-border-0 sm:wpqt-border-r sm:wpqt-border-solid sm:wpqt-border-qtBorder">
                 <div className="wpqt-flex wpqt-items-center wpqt-gap-6">
                   <div
                     className="wpqt-flex wpqt-items-center wpqt-cursor-pointer wpqt-gap-2 wpqt-group"
@@ -115,7 +115,7 @@ function OverviewPage({ pipelineId }: Props) {
                   </div>
                 </div>
               </div>
-              <div className="wpqt-mx-5">
+              <div className="wpqt-mx-2 sm:wpqt-mx-5">
                 {loading ? (
                   <LoadingOval width="28" height="28" />
                 ) : (

--- a/src/pages/OverviewPage/components/NotEnoughData/NotEnoughData.tsx
+++ b/src/pages/OverviewPage/components/NotEnoughData/NotEnoughData.tsx
@@ -3,7 +3,7 @@ type Props = {
 };
 function NotEnoughData({ text }: Props) {
   return (
-    <div className="wpqt-flex wpqt-justify-center wpqt-items-center wpqt-h-[400px] wpqt-w-[500px] wpqt-font-semibold">
+    <div className="wpqt-flex wpqt-justify-center wpqt-items-center wpqt-h-[400px] wpqt-w-full wpqt-max-w-[500px] wpqt-font-semibold">
       {text}
     </div>
   );

--- a/src/pages/OverviewPage/components/PipelineOverview/components/PipelineOverviewContent.tsx
+++ b/src/pages/OverviewPage/components/PipelineOverview/components/PipelineOverviewContent.tsx
@@ -49,22 +49,28 @@ function PipelineOverviewContent({ pipelineOverviewData }: Props) {
           colorClass="wpqt-bg-red-500"
         />
       </div>
-      <div className="wpqt-flex wpqt-flex-wrap wpqt-justify-center">
-        <StageDistributionChart
-          pipelineOverviewData={pipelineOverviewData}
-          options={defaultChartoptions}
-          width="500px"
-        />
-        <TaskStatusChart
-          pipelineOverviewData={pipelineOverviewData}
-          options={defaultChartoptions}
-          width="500px"
-        />
-        <ArhivedTaskChart
-          pipelineOverviewData={pipelineOverviewData}
-          options={defaultChartoptions}
-          width="500px"
-        />
+      <div className="wpqt-flex wpqt-flex-wrap wpqt-justify-center wpqt-gap-4">
+        <div className="wpqt-w-full wpqt-max-w-[500px]">
+          <StageDistributionChart
+            pipelineOverviewData={pipelineOverviewData}
+            options={defaultChartoptions}
+            width="100%"
+          />
+        </div>
+        <div className="wpqt-w-full wpqt-max-w-[500px]">
+          <TaskStatusChart
+            pipelineOverviewData={pipelineOverviewData}
+            options={defaultChartoptions}
+            width="100%"
+          />
+        </div>
+        <div className="wpqt-w-full wpqt-max-w-[500px]">
+          <ArhivedTaskChart
+            pipelineOverviewData={pipelineOverviewData}
+            options={defaultChartoptions}
+            width="100%"
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/pages/OverviewPage/components/StatCard/StatCard.tsx
+++ b/src/pages/OverviewPage/components/StatCard/StatCard.tsx
@@ -7,7 +7,7 @@ type Props = {
 function StatCard({ label, value, colorClass }: Props) {
   return (
     <div
-      className={`wpqt-rounded-lg wpqt-p-6 wpqt-shadow wpqt-text-white wpqt-flex wpqt-flex-col wpqt-items-center wpqt-gap-2 wpqt-min-w-[160px] ${colorClass}`}
+      className={`wpqt-rounded-lg wpqt-p-6 wpqt-shadow wpqt-text-white wpqt-flex wpqt-flex-col wpqt-items-center wpqt-gap-2 wpqt-min-w-0 sm:wpqt-min-w-[160px] ${colorClass}`}
     >
       <span
         className="wpqt-text-4xl wpqt-font-bold"

--- a/src/pages/Page/Page.tsx
+++ b/src/pages/Page/Page.tsx
@@ -11,7 +11,7 @@ function Page({ children }: Props) {
     state: { fullPageLoading },
   } = useContext(LoadingContext);
   return (
-    <div className="wpqt-pr-4">
+    <div className="wpqt-px-3 sm:wpqt-pl-0 sm:wpqt-pr-4">
       {fullPageLoading ? <FullLoading /> : children}
     </div>
   );

--- a/src/pages/PipelinePage/components/PipelineHeader/PipelineHeader.tsx
+++ b/src/pages/PipelinePage/components/PipelineHeader/PipelineHeader.tsx
@@ -26,7 +26,7 @@ function PipelineHeader() {
   }
 
   return (
-    <div className="wpqt-flex wpqt-items-center wpqt-gap-2 wpqt-py-5">
+    <div className="wpqt-flex wpqt-flex-col wpqt-gap-3 wpqt-py-5 xl:wpqt-flex-row xl:wpqt-items-center xl:wpqt-gap-2">
       <div>
         <div className="wpqt-flex wpqt-items-center wpqt-gap-2">
           <div
@@ -41,25 +41,29 @@ function PipelineHeader() {
         )}
       </div>
 
-      <div className="wpqt-ml-auto wpqt-flex wpqt-items-center wpqt-gap-3">
+      <div className="wpqt-flex wpqt-flex-wrap wpqt-items-center wpqt-gap-3 xl:wpqt-ml-auto xl:wpqt-flex-nowrap">
         <BoardOptionsSelection />
-        <TaskExportSelection />
-        <div className="wpqt-mx-5">
-          {loading ? (
-            <LoadingOval width="28" height="28" />
-          ) : (
-            <ArrowPathIcon
-              className="wpqt-size-7 wpqt-cursor-pointer hover:wpqt-text-qtBlueHover"
-              data-testid="refresh-icon"
-              onClick={() => handleRefresh(activePipeline.id)}
-            />
-          )}
-        </div>
+        <div className="wpqt-ml-auto wpqt-flex wpqt-flex-wrap wpqt-items-center wpqt-justify-end wpqt-gap-3 xl:wpqt-ml-0 xl:wpqt-flex-nowrap">
+          <TaskExportSelection />
+          <div className="wpqt-mx-2 sm:wpqt-mx-5">
+            {loading ? (
+              <LoadingOval width="28" height="28" />
+            ) : (
+              <ArrowPathIcon
+                className="wpqt-size-7 wpqt-cursor-pointer hover:wpqt-text-qtBlueHover"
+                data-testid="refresh-icon"
+                onClick={() => handleRefresh(activePipeline.id)}
+              />
+            )}
+          </div>
 
-        <PipelineSelectionDropdown
-          activePipeline={activePipeline}
-          onPipelineClick={(pipelineId) => fetchAndSetPipelineData(pipelineId)}
-        />
+          <PipelineSelectionDropdown
+            activePipeline={activePipeline}
+            onPipelineClick={(pipelineId) =>
+              fetchAndSetPipelineData(pipelineId)
+            }
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/pages/PipelinePage/components/PipelineHeader/components/BoardOptionsSelection/BoardOptionsSelection.tsx
+++ b/src/pages/PipelinePage/components/PipelineHeader/components/BoardOptionsSelection/BoardOptionsSelection.tsx
@@ -56,7 +56,7 @@ function BoardOptionsSelection() {
   };
 
   return (
-    <div className="wpqt-grid wpqt-grid-cols-[auto,auto,auto,auto] wpqt-mr-2 wpqt-pr-4 wpqt-gap-y-2 wpqt-border-0 wpqt-border-r wpqt-border-solid wpqt-border-qtBorder">
+    <div className="wpqt-flex wpqt-flex-wrap wpqt-gap-x-4 wpqt-gap-y-2 sm:wpqt-grid sm:wpqt-grid-cols-[auto,auto,auto,auto] sm:wpqt-gap-x-0 xl:wpqt-mr-2 xl:wpqt-pr-4 xl:wpqt-border-0 xl:wpqt-border-r xl:wpqt-border-solid xl:wpqt-border-qtBorder">
       <div
         className="wpqt-flex wpqt-items-center wpqt-cursor-pointer wpqt-gap-2 wpqt-group"
         onClick={() => {
@@ -69,12 +69,12 @@ function BoardOptionsSelection() {
         </span>
       </div>
 
-      <div className="wpqt-pl-4">
+      <div className="sm:wpqt-pl-4">
         {activePipelineId && <NotificationsNavLink />}
       </div>
 
       <div
-        className="wpqt-flex wpqt-items-center wpqt-cursor-pointer wpqt-gap-2 wpqt-pl-4 wpqt-group"
+        className="wpqt-flex wpqt-items-center wpqt-cursor-pointer wpqt-gap-2 sm:wpqt-pl-4 wpqt-group"
         onClick={toggleView}
       >
         {view === PipelineView.PIPELINE ? (
@@ -97,7 +97,7 @@ function BoardOptionsSelection() {
       {isUserAllowedToManageSettings && (
         <>
           <div
-            className="wpqt-flex wpqt-gap-1 wpqt-items-center wpqt-cursor-pointer wpqt-pl-4 wpqt-group"
+            className="wpqt-flex wpqt-gap-1 wpqt-items-center wpqt-cursor-pointer sm:wpqt-pl-4 wpqt-group"
             onClick={openEditPipelineModal}
           >
             <Cog8ToothIcon className="wpqt-text-blue-400 wpqt-size-5 group-hover:wpqt-text-blue-600" />
@@ -119,7 +119,7 @@ function BoardOptionsSelection() {
           </div>
 
           <div
-            className="wpqt-flex wpqt-items-center wpqt-cursor-pointer wpqt-gap-2 wpqt-pl-4 wpqt-group"
+            className="wpqt-flex wpqt-items-center wpqt-cursor-pointer wpqt-gap-2 sm:wpqt-pl-4 wpqt-group"
             onClick={() => {
               navigatePage(`#/board/${activePipelineId}/webhooks`);
             }}
@@ -131,7 +131,7 @@ function BoardOptionsSelection() {
           </div>
 
           <div
-            className="wpqt-flex wpqt-items-center wpqt-cursor-pointer wpqt-gap-2 wpqt-pl-4 wpqt-group"
+            className="wpqt-flex wpqt-items-center wpqt-cursor-pointer wpqt-gap-2 sm:wpqt-pl-4 wpqt-group"
             onClick={() => {
               navigatePage(`#/board/${activePipelineId}/api-tokens`);
             }}

--- a/src/pages/PipelinePage/components/Stage.tsx
+++ b/src/pages/PipelinePage/components/Stage.tsx
@@ -29,7 +29,7 @@ function Stage({ stage, isLastStage }: Props) {
   return (
     <div
       data-stage-id={stage.id}
-      className={`wpqt-relative wpqt-mb-3 wpqt-flex wpqt-max-h-full wpqt-w-[360px] wpqt-flex-none wpqt-flex-col wpqt-overflow-hidden wpqt-rounded-md wpqt-border wpqt-border-solid wpqt-border-qtBorder wpqt-bg-gray-100`}
+      className={`wpqt-relative wpqt-mb-3 wpqt-flex wpqt-max-h-full wpqt-w-[300px] sm:wpqt-w-[360px] wpqt-flex-none wpqt-flex-col wpqt-overflow-hidden wpqt-rounded-md wpqt-border wpqt-border-solid wpqt-border-qtBorder wpqt-bg-gray-100`}
     >
       <div className="wpqt-mb-4 wpqt-flex wpqt-flex-wrap wpqt-items-center wpqt-gap-1 wpqt-px-4 wpqt-pt-3">
         <div className="wpqt-mr-auto wpqt-flex wpqt-items-center wpqt-gap-2 wpqt-text-base wpqt-leading-none">

--- a/src/pages/UserSessionsPage/components/UserSessions.tsx
+++ b/src/pages/UserSessionsPage/components/UserSessions.tsx
@@ -17,22 +17,24 @@ function UserSessions() {
   }
 
   return (
-    <div className="wpqt-inline-grid wpqt-grid-cols-[auto_auto_auto_auto] wpqt-items-center wpqt-gap-x-16 wpqt-gap-y-4">
-      <div className="wpqt-mb-4 wpqt-font-bold">
-        {__("Session owner", "quicktasker")}
+    <div className="wpqt-overflow-x-auto">
+      <div className="wpqt-inline-grid wpqt-min-w-[640px] wpqt-grid-cols-[auto_auto_auto_auto] wpqt-items-center wpqt-gap-x-16 wpqt-gap-y-4">
+        <div className="wpqt-mb-4 wpqt-font-bold">
+          {__("Session owner", "quicktasker")}
+        </div>
+        <div className="wpqt-mb-4 wpqt-font-bold">
+          {__("Created at", "quicktasker")}
+        </div>
+        <div className="wpqt-mb-4 wpqt-font-bold">
+          {__("Expires at", "quicktasker")}
+        </div>
+        <div className="wpqt-mb-4 wpqt-font-bold">
+          {__("Status", "quicktasker")}
+        </div>
+        {filteredSessions.map((session) => (
+          <UserSession key={session.id} session={session} />
+        ))}
       </div>
-      <div className="wpqt-mb-4 wpqt-font-bold">
-        {__("Created at", "quicktasker")}
-      </div>
-      <div className="wpqt-mb-4 wpqt-font-bold">
-        {__("Expires at", "quicktasker")}
-      </div>
-      <div className="wpqt-mb-4 wpqt-font-bold">
-        {__("Status", "quicktasker")}
-      </div>
-      {filteredSessions.map((session) => (
-        <UserSession key={session.id} session={session} />
-      ))}
     </div>
   );
 }

--- a/src/pages/WebhooksPage/WebhooksPage.tsx
+++ b/src/pages/WebhooksPage/WebhooksPage.tsx
@@ -47,7 +47,7 @@ function WebhooksPageContent({ pipelineId }: Props) {
 
   if (isEmpty) {
     return (
-      <div className="wpqt-max-w-[460px] wpqt-mx-auto wpqt-mt-12 wpqt-border wpqt-border-solid wpqt-border-qtBorder wpqt-rounded-md wpqt-p-6">
+      <div className="wpqt-box-border wpqt-max-w-[460px] wpqt-mx-auto wpqt-mt-12 wpqt-border wpqt-border-solid wpqt-border-qtBorder wpqt-rounded-md wpqt-p-6">
         <h2 className="wpqt-mt-0">
           {__("Create a new webhook", "quicktasker")}
         </h2>
@@ -64,13 +64,13 @@ function WebhooksPageContent({ pipelineId }: Props) {
   }
 
   return (
-    <div className="wpqt-flex wpqt-flex-col lg:wpqt-flex-row wpqt-gap-16">
+    <div className="wpqt-flex wpqt-flex-col lg:wpqt-flex-row wpqt-gap-6 lg:wpqt-gap-16">
       <div className="wpqt-flex-1 wpqt-min-w-0">
         <h2>{__("Created webhooks", "quicktasker")}</h2>
         <PipelineWebhooksInfo />
         <PipelineWebhooks />
       </div>
-      <div className="lg:wpqt-w-[460px] lg:wpqt-shrink-0 wpqt-border wpqt-border-solid wpqt-border-qtBorder wpqt-rounded-md wpqt-p-6 wpqt-self-start">
+      <div className="wpqt-box-border wpqt-w-full wpqt-min-w-0 lg:wpqt-w-[460px] lg:wpqt-shrink-0 wpqt-border wpqt-border-solid wpqt-border-qtBorder wpqt-rounded-md wpqt-p-6 wpqt-self-start">
         <h2 className="wpqt-mt-0">
           {__("Create a new webhook", "quicktasker")}
         </h2>
@@ -116,8 +116,8 @@ function WebhooksPage({ pipelineId }: Props) {
               </a>
             }
             rightSideContent={
-              <div className="wpqt-flex wpqt-items-center wpqt-gap-6">
-                <div className="wpqt-flex wpqt-flex-col wpqt-gap-2 wpqt-mr-2 wpqt-pr-4 wpqt-border-0 wpqt-border-r wpqt-border-solid wpqt-border-qtBorder">
+              <div className="wpqt-flex wpqt-flex-wrap wpqt-items-center wpqt-gap-3 sm:wpqt-gap-6">
+                <div className="wpqt-flex wpqt-flex-col wpqt-gap-2 sm:wpqt-mr-2 sm:wpqt-pr-4 sm:wpqt-border-0 sm:wpqt-border-r sm:wpqt-border-solid sm:wpqt-border-qtBorder">
                   <div className="wpqt-flex wpqt-items-center wpqt-gap-6">
                     <div
                       className="wpqt-flex wpqt-items-center wpqt-cursor-pointer wpqt-gap-2 wpqt-group"
@@ -186,7 +186,7 @@ function RefreshWebhooks() {
   const { loading, refetchPipelineWebhooks } = useWebhooks();
 
   return (
-    <div className="wpqt-mx-5">
+    <div className="wpqt-mx-2 sm:wpqt-mx-5">
       {loading ? (
         <LoadingOval width="28" height="28" />
       ) : (

--- a/src/pages/WebhooksPage/components/WebhookCreator/WebhookCreator.tsx
+++ b/src/pages/WebhooksPage/components/WebhookCreator/WebhookCreator.tsx
@@ -86,7 +86,7 @@ function WebhookCreator({ pipelineId }: Props) {
   return (
     <div className="wpqt-flex wpqt-flex-col wpqt-items-start wpqt-mt-6">
       <div className="wpqt-flex wpqt-gap-4 wpqt-w-full">
-        <div className="wpqt-flex wpqt-flex-col wpqt-flex-1">
+        <div className="wpqt-flex wpqt-flex-col wpqt-flex-1 wpqt-min-w-0">
           <WPQTLabel
             labelFor="webhook-target-type"
             className="wpqt-block wpqt-mb-1"
@@ -95,6 +95,7 @@ function WebhookCreator({ pipelineId }: Props) {
           </WPQTLabel>
           <WPQTSelect
             id="webhook-target-type"
+            className="wpqt-w-full"
             selectedOptionValue={targetType}
             options={Object.values(WebhookTargetType).map((type) => ({
               value: type,
@@ -107,7 +108,7 @@ function WebhookCreator({ pipelineId }: Props) {
           />
         </div>
 
-        <div className="wpqt-flex wpqt-flex-col wpqt-flex-1">
+        <div className="wpqt-flex wpqt-flex-col wpqt-flex-1 wpqt-min-w-0">
           <WPQTLabel
             labelFor="webhook-target-action"
             className="wpqt-block wpqt-mb-1"
@@ -116,6 +117,7 @@ function WebhookCreator({ pipelineId }: Props) {
           </WPQTLabel>
           <WPQTSelect
             id="webhook-target-action"
+            className="wpqt-w-full"
             selectedOptionValue={targetAction}
             options={Object.values(allowedActions).map((action) => ({
               value: action,

--- a/src/user-page-app/index.js
+++ b/src/user-page-app/index.js
@@ -1,4 +1,7 @@
-import { render } from "@wordpress/element";
+import { createRoot } from "@wordpress/element";
 import UserPageApp from "./UserPageApp";
 
-render(<UserPageApp />, document.getElementById("wpqt-public-user-app"));
+const container = document.getElementById("wpqt-public-user-app");
+if (container) {
+  createRoot(container).render(<UserPageApp />);
+}


### PR DESCRIPTION
- Brings the QuickTasker admin React app into a usable state on phone-sized screens (~390px). Desktop layouts are unchanged.
- Switched the admin app and user-page app entry points from the legacy ReactDOM.render to React 18's createRoot(...).render(...) API (via @wordpress/element).
- Eliminates the ReactDOM.render is no longer supported in React 18 console warning and takes both apps out of React-17 compatibility mode.
- Added a defensive null-check on the mount container in both entries (the user-page bundle can load on pages that don't include the mount node).