### PR TITLE
Split user log type into quicktasker_user and wp_user to fix mixed logs

### DIFF
--- a/php/api/admin-api.php
+++ b/php/api/admin-api.php
@@ -1790,7 +1790,7 @@ if (!function_exists('wpqt_register_api_routes')) {
                             'description' => $data['description'],
                         ]);
                         $logService->log('Quicktasker ' . $user->name . ' created', [
-                            'type'          => WP_QT_LOG_TYPE_USER,
+                            'type'          => WP_QT_LOG_TYPE_QUICKTASKER_USER,
                             'type_id'       => $user->id,
                             'user_id'       => get_current_user_id(),
                             'created_by'    => WP_QT_LOG_CREATED_BY_ADMIN,
@@ -1938,7 +1938,7 @@ if (!function_exists('wpqt_register_api_routes')) {
                         ]);
 
                         $logService->log('Task ' . $task->name . ' assigned to ' . $user->name, [
-                            'type'          => WP_QT_LOG_TYPE_USER,
+                            'type'          => WP_QT_WORDPRESS_USER_TYPE === $data['user_type'] ? WP_QT_LOG_TYPE_WP_USER : WP_QT_LOG_TYPE_QUICKTASKER_USER,
                             'type_id'       => $user->id,
                             'user_id'       => $userId,
                             'created_by'    => WP_QT_LOG_CREATED_BY_ADMIN,
@@ -2062,7 +2062,7 @@ if (!function_exists('wpqt_register_api_routes')) {
                         ]);
 
                         $logService->log('User ' . $user->name . ' unassigned from ' . $task->name . ' task', [
-                            'type'          => WP_QT_LOG_TYPE_USER,
+                            'type'          => WP_QT_WORDPRESS_USER_TYPE === $data['user_type'] ? WP_QT_LOG_TYPE_WP_USER : WP_QT_LOG_TYPE_QUICKTASKER_USER,
                             'type_id'       => $user->id,
                             'user_id'       => $userId,
                             'created_by'    => WP_QT_LOG_CREATED_BY_ADMIN,
@@ -2186,7 +2186,7 @@ if (!function_exists('wpqt_register_api_routes')) {
                         $user = $userService->editUser($data['id'], $args);
 
                         $logService->log('User ' . $user->name . ' edited', [
-                            'type'          => WP_QT_LOG_TYPE_USER,
+                            'type'          => WP_QT_LOG_TYPE_QUICKTASKER_USER,
                             'type_id'       => $user->id,
                             'user_id'       => get_current_user_id(),
                             'created_by'    => WP_QT_LOG_CREATED_BY_ADMIN,
@@ -2243,7 +2243,7 @@ if (!function_exists('wpqt_register_api_routes')) {
                         $user = $userService->resetUserPassword($data['id']);
 
                         $logService->log('User ' . $user->name . ' password reset', [
-                            'type'          => WP_QT_LOG_TYPE_USER,
+                            'type'          => WP_QT_LOG_TYPE_QUICKTASKER_USER,
                             'type_id'       => $data['id'],
                             'user_id'       => get_current_user_id(),
                             'created_by'    => WP_QT_LOG_CREATED_BY_ADMIN,
@@ -2289,7 +2289,7 @@ if (!function_exists('wpqt_register_api_routes')) {
                         $user = $userService->changeUserStatus($data['id'], $data['status']);
                         $statusString = $data['status'] ? 'active' : 'disabled';
                         $logService->log('User ' . $user->name . ' status changed to ' . $statusString, [
-                            'type'          => WP_QT_LOG_TYPE_USER,
+                            'type'          => WP_QT_LOG_TYPE_QUICKTASKER_USER,
                             'type_id'       => $data['id'],
                             'user_id'       => get_current_user_id(),
                             'created_by'    => WP_QT_LOG_CREATED_BY_ADMIN,
@@ -2339,7 +2339,7 @@ if (!function_exists('wpqt_register_api_routes')) {
 
                         $user = $userService->deleteUser($data['id']);
                         $logService->log('User ' . $user->name . ' marked as deleted', [
-                            'type'          => WP_QT_LOG_TYPE_USER,
+                            'type'          => WP_QT_LOG_TYPE_QUICKTASKER_USER,
                             'type_id'       => $data['id'],
                             'user_id'       => get_current_user_id(),
                             'created_by'    => WP_QT_LOG_CREATED_BY_ADMIN,

--- a/php/api/user-page-api.php
+++ b/php/api/user-page-api.php
@@ -108,7 +108,7 @@ if (!function_exists('wpqt_register_user_page_api_routes')) {
                     $logService->log('User page setup completed', [
                         'user_id'    => $userPage->user_id,
                         'created_by' => WP_QT_LOG_CREATED_BY_QUICKTASKER_USER,
-                        'type'       => WP_QT_LOG_TYPE_USER,
+                        'type'       => WP_QT_LOG_TYPE_QUICKTASKER_USER,
                         'type_id'    => $userPage->user_id,
                     ]);
 
@@ -158,7 +158,7 @@ if (!function_exists('wpqt_register_user_page_api_routes')) {
                     $logService->log('User logged in', [
                         'user_id'    => $userPage->user_id,
                         'created_by' => WP_QT_LOG_CREATED_BY_QUICKTASKER_USER,
-                        'type'       => WP_QT_LOG_TYPE_USER,
+                        'type'       => WP_QT_LOG_TYPE_QUICKTASKER_USER,
                         'type_id'    => $userPage->user_id,
                     ]);
 
@@ -197,7 +197,7 @@ if (!function_exists('wpqt_register_user_page_api_routes')) {
                         $logService->log('User logged out', [
                            'user_id'    => $requestData['session']->user_id,
                            'created_by' => WP_QT_LOG_CREATED_BY_QUICKTASKER_USER,
-                           'type'       => WP_QT_LOG_TYPE_USER,
+                           'type'       => WP_QT_LOG_TYPE_QUICKTASKER_USER,
                            'type_id'    => $requestData['session']->user_id,
                             ]);
                     } else {
@@ -535,7 +535,7 @@ if (!function_exists('wpqt_register_user_page_api_routes')) {
                     $userComments = $commentRepository->getComments($requestData['session']->user_id, $requestData['userType'], false);
 
                     $logService->log('User posted a comment on its profile', [
-                        'type'       => WP_QT_LOG_TYPE_USER,
+                        'type'       => $requestData['isQuicktaskerUser'] ? WP_QT_LOG_TYPE_QUICKTASKER_USER : WP_QT_LOG_TYPE_WP_USER,
                         'type_id'    => $requestData['session']->user_id,
                         'created_by' => $requestData['isQuicktaskerUser'] ? WP_QT_LOG_CREATED_BY_QUICKTASKER_USER : WP_QT_LOG_CREATED_BY_ADMIN,
                         'user_id'    => $requestData['session']->user_id
@@ -595,7 +595,7 @@ if (!function_exists('wpqt_register_user_page_api_routes')) {
                     $userService->assignTaskToUser($requestData['session']->user_id, $taskId, $requestData['userType']);
 
                     $logService->log('Assigned itself to ' . $task->name . ' task', [
-                        'type'       => WP_QT_LOG_TYPE_USER,
+                        'type'       => $requestData['isQuicktaskerUser'] ? WP_QT_LOG_TYPE_QUICKTASKER_USER : WP_QT_LOG_TYPE_WP_USER,
                         'type_id'    => $requestData['session']->user_id,
                         'created_by' => $createdBy,
                         'user_id'    => $requestData['session']->user_id
@@ -708,7 +708,7 @@ if (!function_exists('wpqt_register_user_page_api_routes')) {
                     $userService->removeTaskFromUser($requestData['session']->user_id, $taskId, $requestData['userType']);
 
                     $logService->log('Unassigned itself from ' . $task->name . ' task', [
-                        'type'        => WP_QT_LOG_TYPE_USER,
+                        'type'        => $requestData['isQuicktaskerUser'] ? WP_QT_LOG_TYPE_QUICKTASKER_USER : WP_QT_LOG_TYPE_WP_USER,
                         'type_id'     => $requestData['session']->user_id,
                         'created_by'  => $createdBy,
                         'user_id'     => $requestData['session']->user_id,
@@ -829,7 +829,7 @@ if (!function_exists('wpqt_register_user_page_api_routes')) {
                         'pipeline_id' => $task->pipeline_id
                     ]);
                     $logService->log('User changed task ' . $task->name . ' stage to ' . $stage->name, [
-                        'type'        => WP_QT_LOG_TYPE_USER,
+                        'type'        => $requestData['isQuicktaskerUser'] ? WP_QT_LOG_TYPE_QUICKTASKER_USER : WP_QT_LOG_TYPE_WP_USER,
                         'type_id'     => $requestData['session']->user_id,
                         'created_by'  => $createdBy,
                         'user_id'     => $requestData['session']->user_id,
@@ -935,7 +935,7 @@ if (!function_exists('wpqt_register_user_page_api_routes')) {
                     $task = $taskRepository->getTaskByHash($data['task_hash']); //Get new task data
 
                     $logService->log($logMessage, [
-                        'type'        => WP_QT_LOG_TYPE_USER,
+                        'type'        => $requestData['isQuicktaskerUser'] ? WP_QT_LOG_TYPE_QUICKTASKER_USER : WP_QT_LOG_TYPE_WP_USER,
                         'type_id'     => $requestData['session']->user_id,
                         'created_by'  => $createdBy,
                         'user_id'     => $requestData['session']->user_id,

--- a/php/constants.php
+++ b/php/constants.php
@@ -60,7 +60,7 @@ DB constants
 */
 
 if (!defined('WP_QUICKTASKER_DB_VERSION')) {
-    define('WP_QUICKTASKER_DB_VERSION', '1.62.0');
+    define('WP_QUICKTASKER_DB_VERSION', '1.63.0');
 }
 
 if (!defined('TABLE_WP_QUICKTASKER_USERS')) {
@@ -169,8 +169,18 @@ if (!defined('WP_QT_LOG_TYPE_STAGE')) {
     define('WP_QT_LOG_TYPE_STAGE', 'stage');
 }
 
+// Legacy: kept so historical 'user' rows remain valid in WP_QT_LOG_TYPES.
+// Do not use for new log writes — use WP_QT_LOG_TYPE_QUICKTASKER_USER or WP_QT_LOG_TYPE_WP_USER.
 if (!defined('WP_QT_LOG_TYPE_USER')) {
     define('WP_QT_LOG_TYPE_USER', 'user');
+}
+
+if (!defined('WP_QT_LOG_TYPE_QUICKTASKER_USER')) {
+    define('WP_QT_LOG_TYPE_QUICKTASKER_USER', 'quicktasker_user');
+}
+
+if (!defined('WP_QT_LOG_TYPE_WP_USER')) {
+    define('WP_QT_LOG_TYPE_WP_USER', 'wp_user');
 }
 
 if (!defined('WP_QT_LOG_TYPE_PIPELINE')) {
@@ -182,7 +192,7 @@ if (!defined('WP_QT_LOG_TYPE_WEBHOOK')) {
 }
 
 if (!defined('WP_QT_LOG_TYPES')) {
-    define('WP_QT_LOG_TYPES', [WP_QT_LOG_TYPE_TASK, WP_QT_LOG_TYPE_PIPELINE, WP_QT_LOG_TYPE_STAGE, WP_QT_LOG_TYPE_USER, WP_QT_LOG_TYPE_WEBHOOK]);
+    define('WP_QT_LOG_TYPES', [WP_QT_LOG_TYPE_TASK, WP_QT_LOG_TYPE_PIPELINE, WP_QT_LOG_TYPE_STAGE, WP_QT_LOG_TYPE_USER, WP_QT_LOG_TYPE_QUICKTASKER_USER, WP_QT_LOG_TYPE_WP_USER, WP_QT_LOG_TYPE_WEBHOOK]);
 }
 
 if (!defined('WP_QT_LOG_CREATED_BY_ADMIN')) {

--- a/php/db.php
+++ b/php/db.php
@@ -120,12 +120,13 @@ if (!function_exists('wpqt_set_up_db')) {
 
             dbDelta($sql6);
 
+            // type ENUM: 'user' and 'users' are legacy values kept for historical rows; new writes use 'quicktasker_user' or 'wp_user'.
             $sql7 = 'CREATE TABLE ' . TABLE_WP_QUICKTASKS_LOGS . " (
 				id int(11) NOT NULL AUTO_INCREMENT,
 				pipeline_id int(11) DEFAULT NULL,
 				text text NOT NULL,
 				type_id int(11) DEFAULT NULL,
-				type ENUM('task', 'pipeline', 'stage', 'user', 'users', 'webhook') NOT NULL,
+				type ENUM('task', 'pipeline', 'stage', 'user', 'users', 'webhook', 'quicktasker_user', 'wp_user') NOT NULL,
 				created_by ENUM('system', 'admin', 'quicktasker_user', 'automation', 'import', 'webhook', 'api_token', 'anonymous', 'wp_user') NOT NULL,
 				created_by_id int(11) DEFAULT NULL,
 				user_id int(11) DEFAULT NULL,

--- a/quicktasker.php
+++ b/quicktasker.php
@@ -8,7 +8,7 @@
     Author URI: https://github.com/SiimKirjanen
     Text Domain: quicktasker
     Domain Path: /languages
-    Version: 1.56.0
+    Version: 1.57.0
     Requires at least: 5.3
     Requires PHP: 7.2.28
     License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: task manager, task management, project management, task board, kanban boar
 Requires at least: 5.3
 Requires PHP: 7.2.28
 Tested up to: 6.9.0
-Stable tag: 1.56.0
+Stable tag: 1.57.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -59,6 +59,12 @@ QuickTasker is an open source kanban-style task management plugin for WordPress.
 
 
 == Changelog ==
+
+= 1.57.0 =
+* Improved mobile experience across admin pages.
+* Reorganized the user details view with separate tabs for details and comments.
+* Moved user activity logs into their own window for easier viewing.
+* Fixed an issue where a user's activity log could show entries from an unrelated user.
 
 = 1.56.0 =
 * Added a "My Tasks" admin page that lists tasks the current user created and tasks assigned to them, gated by a new "Access to My Tasks page" capability.

--- a/src/components/Dropdown/UserDropdown/UserDropdown.tsx
+++ b/src/components/Dropdown/UserDropdown/UserDropdown.tsx
@@ -20,7 +20,7 @@ import {
 import { useUserActions } from "../../../hooks/actions/useUserActions";
 import { ModalContext } from "../../../providers/ModalContextProvider";
 import { UserContext } from "../../../providers/UserContextProvider";
-import { User } from "../../../types/user";
+import { User, UserTypes } from "../../../types/user";
 import { WPQTConfirmTooltip } from "../../Dialog/ConfirmTooltip/ConfirmTooltip";
 import {
   WPQTDropdown,
@@ -110,7 +110,7 @@ function UserDropdown({ user }: Props) {
           e.stopPropagation();
           modalDispatch({
             type: OPEN_USER_LOGS_MODAL,
-            payload: { userId: user.id },
+            payload: { userId: user.id, userType: UserTypes.QUICKTASKER },
           });
         }}
       />

--- a/src/components/Modal/UserLogsModal/UserLogsModal.tsx
+++ b/src/components/Modal/UserLogsModal/UserLogsModal.tsx
@@ -7,6 +7,7 @@ import { ModalContext } from "../../../providers/ModalContextProvider";
 import { WPQTTypes } from "../../../types/enums";
 import { Log } from "../../../types/log";
 import { UserLogsModalSettings } from "../../../types/modal";
+import { UserTypes } from "../../../types/user";
 import { NoFilterResults } from "../../Filter/NoFilterResults/NoFilterResults";
 import { LogsTable } from "../../LogsTable/LogsTable";
 import { WPQTModal, WPQTModalTitle } from "../WPQTModal";
@@ -41,13 +42,18 @@ function UserLogsModalContent({ settings }: UserLogsModalContentProps) {
   const [hasError, setHasError] = useState(false);
 
   const fetchLogs = async () => {
-    if (!settings.userId) return;
+    if (!settings.userId || !settings.userType) return;
 
     setLoadingLogs(true);
     setHasError(false);
 
+    const logType =
+      settings.userType === UserTypes.QUICKTASKER
+        ? WPQTTypes.QuicktaskerUser
+        : WPQTTypes.WpUser;
+
     try {
-      const response = await getLogsRequest(settings.userId, WPQTTypes.User);
+      const response = await getLogsRequest(settings.userId, logType);
       setLogs(response.data);
     } catch (error) {
       console.error("Error fetching user logs:", error);
@@ -61,7 +67,7 @@ function UserLogsModalContent({ settings }: UserLogsModalContentProps) {
     if (settings.userId) {
       fetchLogs();
     }
-  }, [settings.userId]);
+  }, [settings.userId, settings.userType]);
 
   return (
     <div className="wpqt-flex wpqt-flex-col wpqt-gap-4">

--- a/src/components/Modal/UserModal/UserModalContent.tsx
+++ b/src/components/Modal/UserModal/UserModalContent.tsx
@@ -165,7 +165,10 @@ const UserModalContent = () => {
             onClick={() => {
               modalDispatch({
                 type: OPEN_USER_LOGS_MODAL,
-                payload: { userId: userToEdit.id },
+                payload: {
+                  userId: userToEdit.id,
+                  userType: UserTypes.QUICKTASKER,
+                },
               });
             }}
           />

--- a/src/pages/PipelinePage/components/PipelineHeader/PipelineHeader.test.tsx
+++ b/src/pages/PipelinePage/components/PipelineHeader/PipelineHeader.test.tsx
@@ -91,7 +91,7 @@ describe("PipelineHeader", () => {
     taskLogsModalOpen: false,
     taskLogsModalSettings: { taskId: null },
     userLogsModalOpen: false,
-    userLogsModalSettings: { userId: null },
+    userLogsModalSettings: { userId: null, userType: null },
     notificationsModalOpen: false,
   };
 

--- a/src/providers/ModalContextProvider.tsx
+++ b/src/providers/ModalContextProvider.tsx
@@ -61,7 +61,7 @@ import {
 import { Pipeline } from "../types/pipeline";
 import { Stage } from "../types/stage";
 import { Task, TaskExportMethods } from "../types/task";
-import { User, WPUser } from "../types/user";
+import { User, UserTypes, WPUser } from "../types/user";
 
 const initialState: State = {
   taskModalOpen: false,
@@ -118,6 +118,7 @@ const initialState: State = {
   userLogsModalOpen: false,
   userLogsModalSettings: {
     userId: null,
+    userType: null,
   },
   notificationsModalOpen: false,
 };
@@ -251,7 +252,7 @@ type Action =
   | { type: typeof CLOSE_TASK_LOGS_MODAL }
   | {
       type: typeof OPEN_USER_LOGS_MODAL;
-      payload: { userId: string };
+      payload: { userId: string; userType: UserTypes };
     }
   | { type: typeof CLOSE_USER_LOGS_MODAL }
   | { type: typeof OPEN_NOTIFICATIONS_MODAL }

--- a/src/reducers/modal-reducer.ts
+++ b/src/reducers/modal-reducer.ts
@@ -431,7 +431,7 @@ const reducer = (state: State, action: Action): State => {
       };
     }
     case OPEN_USER_LOGS_MODAL: {
-      const { userId }: { userId: string } = action.payload;
+      const { userId, userType } = action.payload;
 
       return {
         ...state,
@@ -439,6 +439,7 @@ const reducer = (state: State, action: Action): State => {
         userLogsModalSettings: {
           ...state.userLogsModalSettings,
           userId,
+          userType,
         },
       };
     }

--- a/src/types/enums.tsx
+++ b/src/types/enums.tsx
@@ -1,6 +1,8 @@
 enum WPQTTypes {
   Task = "task",
   User = "user",
+  QuicktaskerUser = "quicktasker_user",
+  WpUser = "wp_user",
 }
 
 enum WPQTLogCreatedBy {

--- a/src/types/modal.ts
+++ b/src/types/modal.ts
@@ -1,4 +1,5 @@
 import { Task, TaskExportMethods } from "./task";
+import { UserTypes } from "./user";
 
 type TaskModalSettings = {
   allowToMarkTaskAsDone: boolean;
@@ -30,6 +31,7 @@ type TaskLogsModalSettings = {
 
 type UserLogsModalSettings = {
   userId: string | null;
+  userType: UserTypes | null;
 };
 
 export type {


### PR DESCRIPTION
The logs table used type='user' for both quicktasker users and WP users,
so logs for a quicktasker user with id=1 also surfaced unrelated WP user
(e.g. admin) activity. Split into 'quicktasker_user' and 'wp_user' and
thread the user kind through the modal → API request so reads stay
disjoint. Legacy 'user'/'users' ENUM values kept for historical rows.