### PR TITLE
Add refresh button to User management page

### DIFF
--- a/src/components/Dropdown/UserAssignementDropdown/components/UserAssignementSelection/UserAssignementSelection.test.tsx
+++ b/src/components/Dropdown/UserAssignementDropdown/components/UserAssignementSelection/UserAssignementSelection.test.tsx
@@ -99,6 +99,7 @@ function renderWithProviders(props: UserAssignementSelectionProps) {
           },
           userDispatch: jest.fn(),
           updateUsers: jest.fn(),
+          updateWPUsers: jest.fn(),
         }}
       >
         <UserAssignementSelection {...props} />

--- a/src/components/common/Select/WPQTSelect.tsx
+++ b/src/components/common/Select/WPQTSelect.tsx
@@ -33,7 +33,7 @@ function WPQTSelect({
       id={id}
       value={selectedOptionValue}
       onChange={handleChange}
-      className={`!wpqt-rounded-lg !wpqt-border !wpqt-border-solid !wpqt-border-qtBorder !wpqt-px-2 !wpqt-pr-6 !wpqt-py-1 focus:wpqt-outline-none data-[focus]:wpqt-outline-2 data-[focus]:wpqt--outline-offset-2 data-[focus]:wpqt-outline-gray-300 ${className}`}
+      className={`!wpqt-rounded-lg !wpqt-border !wpqt-border-solid !wpqt-border-qtBorder !wpqt-px-2 !wpqt-pr-6 !wpqt-py-1 !wpqt-leading-6 focus:wpqt-outline-none data-[focus]:wpqt-outline-2 data-[focus]:wpqt--outline-offset-2 data-[focus]:wpqt-outline-gray-300 ${className}`}
     >
       {allSelector && <option value="">{allSelectorLabel}</option>}
       {options.map((option) => (

--- a/src/hooks/filters/useUserFilter.test.tsx
+++ b/src/hooks/filters/useUserFilter.test.tsx
@@ -26,7 +26,12 @@ function makeUser(overrides: Partial<User> = {}): User {
 }
 
 function wrapper(state: State) {
-  const ctx = { state, userDispatch: jest.fn(), updateUsers: jest.fn() };
+  const ctx = {
+    state,
+    userDispatch: jest.fn(),
+    updateUsers: jest.fn(),
+    updateWPUsers: jest.fn(),
+  };
   const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
     <UserContext.Provider value={ctx}>{children}</UserContext.Provider>
   );

--- a/src/pages/MyTasksPage/components/MyTasksHeaderControls.tsx
+++ b/src/pages/MyTasksPage/components/MyTasksHeaderControls.tsx
@@ -35,7 +35,7 @@ function MyTasksHeaderControls({
         selectedOptionValue={boardFilter}
         onSelectionChange={onBoardFilterChange}
         allSelectorLabel={__("All boards", "quicktasker")}
-        className="!wpqt-h-[30px] !wpqt-min-h-[30px] !wpqt-py-[0px] !wpqt-pl-2 !wpqt-pr-6 !wpqt-text-sm/6 !wpqt-leading-[28px] !wpqt-shadow-none"
+        className="!wpqt-shadow-none"
       />
       <WPQTInput
         value={searchValue}

--- a/src/pages/UserManagement/RegularWPUserSection/ReqularWPUsersSection.tsx
+++ b/src/pages/UserManagement/RegularWPUserSection/ReqularWPUsersSection.tsx
@@ -1,42 +1,21 @@
 import { MagnifyingGlassIcon, UserPlusIcon } from "@heroicons/react/24/outline";
-import { useEffect, useState } from "@wordpress/element";
+import { useContext, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
-import { getWPUsersRequest } from "../../../api/api";
 import { WPQTIconButton } from "../../../components/common/Button/WPQTIconButton/WPQTIconButton";
 import { WPQTInput } from "../../../components/common/Input/Input";
 import { NoFilterResults } from "../../../components/Filter/NoFilterResults/NoFilterResults";
-import { Loading } from "../../../components/Loading/Loading";
-import { WPQTWpUserTypes } from "../../../types/enums";
-import { WPUser } from "../../../types/user";
+import { UserContext } from "../../../providers/UserContextProvider";
 import { WPUserItem } from "../components/WPUserItem/WPUserItem";
 
 function RegularWPUsersSection() {
-  const [users, setUsers] = useState<WPUser[] | null>(null);
-  const [loading, setLoading] = useState(true);
+  const {
+    state: { wpUsers },
+  } = useContext(UserContext);
   const [searchValue, setSearchValue] = useState("");
 
-  useEffect(() => {
-    const fetchUsers = async () => {
-      try {
-        setLoading(true);
-        const response = await getWPUsersRequest(WPQTWpUserTypes.Other);
-        setUsers(response.data);
-      } catch (error) {
-        console.error(error);
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchUsers();
-  }, []);
+  const hasUsers = wpUsers.length > 0;
 
-  if (loading || users === null) {
-    return <Loading ovalSize="48" />;
-  }
-
-  const hasUsers = users.length > 0;
-
-  const filteredUsers = users.filter((user) =>
+  const filteredUsers = wpUsers.filter((user) =>
     user.name.toLowerCase().includes(searchValue.toLowerCase()),
   );
 

--- a/src/pages/UserManagement/UserManagement.test.tsx
+++ b/src/pages/UserManagement/UserManagement.test.tsx
@@ -1,0 +1,179 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import {
+  CHANGE_USER_SETTINGS_MODAL_OPEN,
+  SET_FULL_PAGE_LOADING,
+} from "../../constants";
+import { LoadingContext } from "../../providers/LoadingContextProvider";
+import { ModalContext } from "../../providers/ModalContextProvider";
+import { UserContext } from "../../providers/UserContextProvider";
+
+jest.mock("../Page/Page", () => ({
+  Page: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock("../../components/common/Header/Header", () => ({
+  WPQTPageHeader: ({
+    children,
+    rightSideContent,
+  }: {
+    children: React.ReactNode;
+    rightSideContent?: React.ReactNode;
+  }) => (
+    <div>
+      <h1>{children}</h1>
+      {rightSideContent}
+    </div>
+  ),
+}));
+
+jest.mock("../../components/Tab/WPQTTabs", () => ({
+  WPQTTabs: () => <div data-testid="tabs" />,
+}));
+
+jest.mock(
+  "../../components/Modal/UsersSettingsModal/UsersSettingsModal",
+  () => ({
+    UsersSettingsModal: () => null,
+  }),
+);
+
+jest.mock("../../components/Loading/Loading", () => ({
+  LoadingOval: () => <div data-testid="loading-oval" />,
+}));
+
+jest.mock("./QuickTaskersSection/QuickTaskersSection", () => ({
+  QuickTaskersSection: () => null,
+}));
+
+jest.mock("./RegularWPUserSection/ReqularWPUsersSection", () => ({
+  RegularWPUsersSection: () => null,
+}));
+
+import { UserManagement } from "./UserManagement";
+
+type CtxOverrides = {
+  updateUsers?: jest.Mock;
+  updateWPUsers?: jest.Mock;
+  modalDispatch?: jest.Mock;
+  loadingDispatch?: jest.Mock;
+};
+
+function renderPage({
+  updateUsers = jest.fn().mockResolvedValue(undefined),
+  updateWPUsers = jest.fn().mockResolvedValue(undefined),
+  modalDispatch = jest.fn(),
+  loadingDispatch = jest.fn(),
+}: CtxOverrides = {}) {
+  const result = render(
+    <LoadingContext.Provider
+      value={{ state: { fullPageLoading: false }, loadingDispatch }}
+    >
+      <ModalContext.Provider value={{ state: {} as never, modalDispatch }}>
+        <UserContext.Provider
+          value={{
+            state: { users: [], wpUsers: [], usersSearchValue: "" },
+            userDispatch: jest.fn(),
+            updateUsers,
+            updateWPUsers,
+          }}
+        >
+          <UserManagement />
+        </UserContext.Provider>
+      </ModalContext.Provider>
+    </LoadingContext.Provider>,
+  );
+  return {
+    ...result,
+    updateUsers,
+    updateWPUsers,
+    modalDispatch,
+    loadingDispatch,
+  };
+}
+
+describe("UserManagement", () => {
+  it("fetches both user lists on mount with a full-page loader", async () => {
+    let updateUsers!: jest.Mock;
+    let updateWPUsers!: jest.Mock;
+    let loadingDispatch!: jest.Mock;
+    await act(async () => {
+      ({ updateUsers, updateWPUsers, loadingDispatch } = renderPage());
+    });
+
+    expect(updateUsers).toHaveBeenCalledTimes(1);
+    expect(updateWPUsers).toHaveBeenCalledTimes(1);
+    expect(loadingDispatch).toHaveBeenCalledWith({
+      type: SET_FULL_PAGE_LOADING,
+      payload: true,
+    });
+    expect(loadingDispatch).toHaveBeenLastCalledWith({
+      type: SET_FULL_PAGE_LOADING,
+      payload: false,
+    });
+  });
+
+  it("re-fetches both user lists when the refresh icon is clicked", async () => {
+    let updateUsers!: jest.Mock;
+    let updateWPUsers!: jest.Mock;
+    await act(async () => {
+      ({ updateUsers, updateWPUsers } = renderPage());
+    });
+
+    expect(updateUsers).toHaveBeenCalledTimes(1);
+    expect(updateWPUsers).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("refresh-icon"));
+    });
+
+    expect(updateUsers).toHaveBeenCalledTimes(2);
+    expect(updateWPUsers).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows the loading oval while refreshing and restores the icon after", async () => {
+    let resolveUsers!: () => void;
+    const updateUsers = jest
+      .fn()
+      .mockImplementationOnce(() => Promise.resolve())
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((r) => {
+            resolveUsers = r;
+          }),
+      );
+    const updateWPUsers = jest.fn().mockResolvedValue(undefined);
+
+    await act(async () => {
+      renderPage({ updateUsers, updateWPUsers });
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("refresh-icon"));
+    });
+    expect(screen.queryByTestId("refresh-icon")).not.toBeInTheDocument();
+    expect(screen.getByTestId("loading-oval")).toBeInTheDocument();
+
+    await act(async () => {
+      resolveUsers();
+    });
+    expect(screen.getByTestId("refresh-icon")).toBeInTheDocument();
+    expect(screen.queryByTestId("loading-oval")).not.toBeInTheDocument();
+  });
+
+  it("opens the users settings modal when Settings is clicked", async () => {
+    let modalDispatch!: jest.Mock;
+    await act(async () => {
+      ({ modalDispatch } = renderPage());
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Settings"));
+    });
+
+    expect(modalDispatch).toHaveBeenCalledWith({
+      type: CHANGE_USER_SETTINGS_MODAL_OPEN,
+      payload: true,
+    });
+  });
+});

--- a/src/pages/UserManagement/UserManagement.tsx
+++ b/src/pages/UserManagement/UserManagement.tsx
@@ -1,9 +1,10 @@
-import { Cog8ToothIcon } from "@heroicons/react/24/outline";
-import { useContext, useEffect } from "@wordpress/element";
+import { ArrowPathIcon, Cog8ToothIcon } from "@heroicons/react/24/outline";
+import { useContext, useEffect, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { WPQTPageHeader } from "../../components/common/Header/Header";
 import { QuickTaskerIcon } from "../../components/Icon/QuickTaskerIcon/QuickTaskerIcon";
 import { WordPressIcon } from "../../components/Icon/WordPressIcon/WordPressIcon";
+import { LoadingOval } from "../../components/Loading/Loading";
 import { UsersSettingsModal } from "../../components/Modal/UsersSettingsModal/UsersSettingsModal";
 import { WPQTTabs } from "../../components/Tab/WPQTTabs";
 import {
@@ -18,9 +19,10 @@ import { QuickTaskersSection } from "./QuickTaskersSection/QuickTaskersSection";
 import { RegularWPUsersSection } from "./RegularWPUserSection/ReqularWPUsersSection";
 
 function UserManagement() {
-  const { updateUsers } = useContext(UserContext);
+  const { updateUsers, updateWPUsers } = useContext(UserContext);
   const { loadingDispatch } = useContext(LoadingContext);
   const { modalDispatch } = useContext(ModalContext);
+  const [refreshing, setRefreshing] = useState(false);
 
   const tabDefinitions = [
     {
@@ -40,11 +42,17 @@ function UserManagement() {
   useEffect(() => {
     const updateUsersAsync = async () => {
       loadingDispatch({ type: SET_FULL_PAGE_LOADING, payload: true });
-      await updateUsers();
+      await Promise.all([updateUsers(), updateWPUsers()]);
       loadingDispatch({ type: SET_FULL_PAGE_LOADING, payload: false });
     };
     updateUsersAsync();
   }, []);
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    await Promise.all([updateUsers(), updateWPUsers()]);
+    setRefreshing(false);
+  };
 
   const description = __(
     "Manage access for users of this plugin.\n WordPress admins have full access by default. Other WordPress users have no access by default but can be granted permissions.\n QuickTaskers are plugin-managed users who access tasks through the tasks app and have no access to the WordPress admin area.",
@@ -56,20 +64,33 @@ function UserManagement() {
       <WPQTPageHeader
         description={description}
         rightSideContent={
-          <span
-            className="wpqt-inline-flex wpqt-items-center wpqt-cursor-pointer wpqt-text-blue-500 wpqt-group wpqt-gap-1 wpqt-border wpqt-border-solid wpqt-border-blue-400 wpqt-rounded wpqt-px-3 wpqt-py-1 hover:wpqt-bg-blue-50 hover:wpqt-border-blue-600"
-            onClick={() => {
-              modalDispatch({
-                type: CHANGE_USER_SETTINGS_MODAL_OPEN,
-                payload: true,
-              });
-            }}
-          >
-            <Cog8ToothIcon className="wpqt-size-4 group-hover:wpqt-text-blue-600" />
-            <span className="wpqt-text-sm wpqt-blue-text group-hover:wpqt-text-blue-600">
-              {__("Settings", "quicktasker")}
-            </span>
-          </span>
+          <div className="wpqt-flex wpqt-items-center wpqt-gap-3 sm:wpqt-gap-4">
+            <div
+              className="wpqt-flex wpqt-gap-1 wpqt-items-center wpqt-cursor-pointer wpqt-group"
+              onClick={() => {
+                modalDispatch({
+                  type: CHANGE_USER_SETTINGS_MODAL_OPEN,
+                  payload: true,
+                });
+              }}
+            >
+              <Cog8ToothIcon className="wpqt-text-blue-400 wpqt-size-5 group-hover:wpqt-text-blue-600" />
+              <span className="wpqt-text-sm wpqt-blue-text group-hover:wpqt-text-blue-600">
+                {__("Settings", "quicktasker")}
+              </span>
+            </div>
+            <div className="wpqt-mx-2 sm:wpqt-mx-5">
+              {refreshing ? (
+                <LoadingOval width="28" height="28" />
+              ) : (
+                <ArrowPathIcon
+                  className="wpqt-size-7 wpqt-cursor-pointer hover:wpqt-text-qtBlueHover"
+                  data-testid="refresh-icon"
+                  onClick={handleRefresh}
+                />
+              )}
+            </div>
+          </div>
         }
       >
         {__("User management", "quicktasker")}

--- a/src/providers/UserContextProvider.tsx
+++ b/src/providers/UserContextProvider.tsx
@@ -1,7 +1,7 @@
 import { createContext, useEffect, useReducer } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { toast } from "react-toastify";
-import { getUsersRequest } from "../api/api";
+import { getUsersRequest, getWPUsersRequest } from "../api/api";
 import {
   ADD_USER,
   CHANGE_USER_STATUS,
@@ -13,6 +13,7 @@ import {
   SET_WP_USERS,
 } from "../constants";
 import { reducer } from "../reducers/user-reducer";
+import { WPQTWpUserTypes } from "../types/enums";
 import { ServerUser, User, WPUser } from "../types/user";
 
 const initialState: State = {
@@ -46,12 +47,14 @@ type UserContextType = {
   state: State;
   userDispatch: Dispatch;
   updateUsers: () => Promise<void>;
+  updateWPUsers: () => Promise<void>;
 };
 
 const UserContext = createContext<UserContextType>({
   state: initialState,
   userDispatch: () => {},
   updateUsers: async () => {},
+  updateWPUsers: async () => {},
 });
 
 const UserContextProvider = ({ children }: { children: React.ReactNode }) => {
@@ -78,8 +81,20 @@ const UserContextProvider = ({ children }: { children: React.ReactNode }) => {
     }
   };
 
+  const updateWPUsers = async () => {
+    try {
+      const response = await getWPUsersRequest(WPQTWpUserTypes.Other);
+      userDispatch({ type: SET_WP_USERS, payload: response.data });
+    } catch (error) {
+      console.error(error);
+      toast.error(__("Failed to fetch WordPress users", "quicktasker"));
+    }
+  };
+
   return (
-    <UserContext.Provider value={{ state, userDispatch, updateUsers }}>
+    <UserContext.Provider
+      value={{ state, userDispatch, updateUsers, updateWPUsers }}
+    >
       {children}
     </UserContext.Provider>
   );


### PR DESCRIPTION
- Add refresh control to the User management page header; lift WP-user fetching into UserContext so it refreshes both tabs.
- Fix WPQTSelect rendering taller than WPQTInput (WP admin's line-height: 38px was overriding min-height).
- Add Jest tests for the new User management header behavior.